### PR TITLE
DeleteCases of " " to restore original ConvertToWikipediaSearchQuery behavior

### DIFF
--- a/TextPatternCases.wl
+++ b/TextPatternCases.wl
@@ -115,7 +115,7 @@ WikipediaSearchQuery[wsq_List, tp_TextPattern] := Cases[List[(_List|_String)..]]
 ConvertToWikipediaSearchQuery[tp_TextPattern]:= Module[
 	{cleanTextPattern, stage1},
 	cleanTextPattern = DeleteCases[List@@tp, (_TextType | _OptionalTextPattern | _OrderlessTextPattern), All];
-	stage1 = ReplaceAll[cleanTextPattern, {Alternatives -> List}];
+	stage1 = ReplaceAll[cleanTextPattern, {Alternatives -> List}]//DeleteCases[" "];
 	Check[WikipediaSearchQuery[stage1, tp] // StringReplace[(" " ..) -> " "], Return[$Failed, Module]]
 	]
 


### PR DESCRIPTION
Restores original behavior of ConvertToWikipediaSearchQuery to prevent alternatives from combining into a single string.

```Mathematica
tpmv1 = TextPattern[TextType["Determiner"], " ", "king" | "queen"];

In[129]:= ConvertToWikipediaSearchQuery[tpmv1]
Out[129]= {"king queen"}

In[133]:= ConvertToWikipediaSearchQuery[tpmv1]

Out[133]= {"king", "queen"}
```

Closes #36 