### PR TITLE
Support Pattern Symbols in ToTextElementStructure

### DIFF
--- a/LexicalCases.wl
+++ b/LexicalCases.wl
@@ -60,13 +60,15 @@ ValidLexicalPatternQ[RuleDelayed[input_LexicalPattern,_]]:= ValidLexicalPatternQ
 (* Format LexicalPatterns for strings *)
 TextElementFormat[s_String] := s
 TextElementFormat[re_RegularExpression] := ToString[re]
-TextElementFormat[a_Alternatives] :=TextElement[ToString[a], <|"GrammaticalUnit" -> "Alternatives"|>]
+TextElementFormat[a_Alternatives] := TextElement[ToString[a], <|"GrammaticalUnit" -> "Alternatives"|>]
 TextElementFormat[LexicalPattern[args__]] :=TextElement[Map[TextElementFormat]@{args}, <|"GrammaticalUnit" -> "LexicalPattern"|>];
 TextElementFormat[LexicalPatternSequence[args__]] :=TextElement[Map[TextElementFormat]@{args}, <|"GrammaticalUnit" -> "Sequence"|>];
 TextElementFormat[OrderlessLexicalPattern[args__]] :=TextElement[Map[TextElementFormat]@{args}, <|"GrammaticalUnit" -> "Orderless"|>];
 TextElementFormat[OptionalLexicalPattern[args__]] :=TextElement[Map[TextElementFormat]@{args}, <|"GrammaticalUnit" -> "Optional"|>];
 TextElementFormat[TextType[type_String]] :=TextElement[type, <|"GrammaticalUnit" -> "TextType"|>];
 TextElementFormat[TextType[type_RegularExpression]] :=TextElement[ToString[type], <|"GrammaticalUnit" -> "TextType"|>];
+TextElementFormat[x_[args__]] := TextElement[Map[TextElementFormat]@{args}, <|"GrammaticalUnit" -> ToString[x]|>]
+TextElementFormat[sym_Symbol] := ToString[sym]
 
 ToTextElementStructure[lp_LexicalPattern] := TextElementFormat[lp];
 ToTextElementStructure[(Rule|RuleDelayed)[lp_LexicalPattern,_]] := TextElementFormat[StripNamedPattern@lp];


### PR DESCRIPTION
Add catch-all TextElementFormat definitions for x[args] and Symbols. Allowing for Repeated[DigitCharacter] for example.

<img width="1106" alt="Screen Shot 2021-11-25 at 8 06 50 AM" src="https://user-images.githubusercontent.com/18143853/143447163-afd76dd7-e9ba-4636-bb67-8134d64d7ab0.png">

Closes #51 