### PR TITLE
Split out args in TextElementFormat definition for Repeated and Except

### DIFF
--- a/LexicalCases.wl
+++ b/LexicalCases.wl
@@ -67,7 +67,7 @@ TextElementFormat[OrderlessLexicalPattern[args__]] :=TextElement[Map[TextElement
 TextElementFormat[OptionalLexicalPattern[args__]] :=TextElement[Map[TextElementFormat]@{args}, <|"GrammaticalUnit" -> "Optional"|>];
 TextElementFormat[TextType[type_String]] :=TextElement[type, <|"GrammaticalUnit" -> "TextType"|>];
 TextElementFormat[TextType[type_RegularExpression]] :=TextElement[ToString[type], <|"GrammaticalUnit" -> "TextType"|>];
-TextElementFormat[x_[args__]] := TextElement[Map[TextElementFormat]@{args}, <|"GrammaticalUnit" -> ToString[x]|>]
+TextElementFormat[x_[arg1_,args___]] := TextElement[Map[TextElementFormat]@{arg1}, <|"GrammaticalUnit" -> ToString[x]|>]
 TextElementFormat[sym_Symbol] := ToString[sym]
 TextElementFormat[x_] := x
 


### PR DESCRIPTION
<img width="1182" alt="Screen Shot 2021-11-25 at 3 59 58 PM" src="https://user-images.githubusercontent.com/18143853/143499420-577eff41-1ebb-4ba5-a7fc-b7860ca8d314.png">

Closes #53 