### PR TITLE
LexicalCases is now listable

### DIFF
--- a/LexicalCases.wl
+++ b/LexicalCases.wl
@@ -134,6 +134,7 @@ Options[LexicalCasesWikipedia] = {
 };
 
 $LexicalCasesSupportedServices = {"Wikipedia"}
+SetAttributes[LexicalCases, Listable]
 (* SourceText and LexicalPattern Input *)
 LexicalCases[sourcetext_String, lpatt_?ValidLexicalPatternQ]:= Module[
 	{lpC},


### PR DESCRIPTION
Making LexicalCases Listable means a list of texts can be passed in and a separate LexicalSummary is generated for each. For larger texts and complex patterns this may be a problem because it may end up being expensive, but for modest string inputs it should be fine.

Closes #60 