### PR TITLE
Add support for File objects

### DIFF
--- a/LexicalCases.wl
+++ b/LexicalCases.wl
@@ -135,6 +135,12 @@ Options[LexicalCasesWikipedia] = {
 
 $LexicalCasesSupportedServices = {"Wikipedia"}
 SetAttributes[LexicalCases, Listable]
+LexicalCases::unsupobj=Import::unsupobj;
+GetFileExtension[file_File] := Information[file, "FileExtension"]
+SupportedFileQ[file_File] := MemberQ[{"txt", "md", "csv", "tsv"}, GetFileExtension[file]]
+LexicalCases[file_File, args___] /; SupportedFileQ[file] := Module[{data = Import[file]}, LexicalCases[data, args]]
+LexicalCases[file_File, args___] := Message[LexicalCases::unsupobj, GetFileExtension[file]]
+
 (* SourceText and LexicalPattern Input *)
 LexicalCases[sourcetext_String, lpatt_?ValidLexicalPatternQ]:= Module[
 	{lpC},


### PR DESCRIPTION
<img width="1140" alt="Screen Shot 2021-11-26 at 11 38 18 PM" src="https://user-images.githubusercontent.com/18143853/143668237-d494bbc8-23fb-41e3-b740-cfab7019d7e7.png">

Unsupported file types will issue a message, otherwise, the file is imported and searched.