### PR TITLE
Define MatchBoundary for OptionalLexicalPattern and TextType

### DIFF
--- a/LexicalCases.wl
+++ b/LexicalCases.wl
@@ -100,12 +100,14 @@ ToTextElementStructure[(Rule|RuleDelayed)[lp_LexicalPattern,_]] := Construct[Tex
 
 ExpandAlternativeTextTypes[alts_Alternatives] := (Apply[Alternatives]@*Map[TextType]@*Apply[List])[alts]
 
+MatchBoundary[patt_] := Except[WordCharacter]~~patt~~Except[WordCharacter]
+
 ExpandLexicalPattern[lp_LexicalPattern] := ReplaceAll[lp, {
 	LexicalPattern -> StringExpression,
 	LexicalPatternSequence -> StringExpression,
 	OrderlessLexicalPattern -> Function[Alternatives@@Map[Apply[StringExpression]][Permutations[{##}]]],
-	OptionalLexicalPattern[opt_Alternatives] :> (opt~Join~Alternatives[""]),
-	OptionalLexicalPattern[opt_] :> (Alternatives[opt]~Join~Alternatives[""]),
+	OptionalLexicalPattern[opt_Alternatives] :> (Map[MatchBoundary][opt]~Join~Alternatives[" ",""]),
+	OptionalLexicalPattern[opt_] :> (Alternatives[MatchBoundary[opt]]~Join~Alternatives[" ",""]),
 	TextType[alts_Alternatives] :> ExpandAlternativeTextTypes[alts]
 	}]
 

--- a/LexicalCasesTests.wl
+++ b/LexicalCasesTests.wl
@@ -115,7 +115,7 @@ $LexicalCasesTests := {
 	],
 	(* Short Strings *)
 	VerificationTest[
-		LexicalCases[$SampleStringShort, $SampleLexicalPattern, "StringTrim" -> True]["Data"],
+		LexicalCases[$SampleStringShort, $SampleLexicalPattern]["Data"],
 		{<|"Match" -> "best key lime pie", "Position" -> {{5, 21}}|>},
 		"TestID" -> "ShortStringTest1"
 		]

--- a/LexicalCasesTests.wl
+++ b/LexicalCasesTests.wl
@@ -86,13 +86,18 @@ $LexicalCasesTests := {
 	(* LexicalPatternToStringExpression *)
 	VerificationTest[
 		LexicalPatternToStringExpression[$SampleStringLong, LexicalPattern["computer" | "computers", " ", TextType["Verb"]]],
-		StringExpression[
-			Alternatives["computer","computers"]," ",
-			Alternatives[
-				"allow","automate","be","can","carry","change","chip","circuit","cluster","complete","control","design","enable","form","full","function","group","have","include","input","like","long","machine","microwave","monitor","network","order","out","output","pace","people","perform","power","range","refer","result","source","speed","term","type","use","well","is","programmed","known","includes","operating","needed","used","may","are","linked","included","links","were","meant","aided","doing","built","guiding","did","specialized","calculating","developed","followed","integrated","leading","been","increasing","counts","predicted","consists","carries","stored","retrieved","saved"
-				]
-			],
-		"TestID" -> "LexicalPatternToRegularExpressionTest1"
+			StringExpression[
+				Alternatives["computer","computers"]," ",
+				Except[WordCharacter,Alternatives[WordBoundary," "]],
+				Alternatives[
+				"allow","automate","be","can","carry","change","chip","circuit","cluster","complete","control","design","enable","form","full","function","group","have","include","input","like",
+				"long","machine","microwave","monitor","network","order","out","output","pace","people","perform","power","range","refer","result","source","speed","term","type","use","well","is",
+				"programmed","known","includes","operating","needed","used","may","are","linked","included","links","were","meant","aided","doing","built","guiding","did","specialized",
+				"calculating","developed","followed","integrated","leading","been","increasing","counts","predicted","consists","carries","stored","retrieved","saved"
+				],
+				Except[WordCharacter,Alternatives[WordBoundary," "]]
+				],
+		"TestID" -> "LexicalPatternToStringExpressionTest1"
 	],
 	(* ToTextElementStructure *)
 	VerificationTest[
@@ -106,11 +111,11 @@ $LexicalCasesTests := {
 		Association["GrammaticalUnit" -> "LexicalPattern"]
 		]
 	,
-	"TestID" -> "LexicalPatternToRegularExpressionTest1"
+	"TestID" -> "ToTextElementStructureTest1"
 	],
 	(* Short Strings *)
 	VerificationTest[
-		LexicalCases[$SampleStringShort, $SampleLexicalPattern]["Data"],
+		LexicalCases[$SampleStringShort, $SampleLexicalPattern, "StringTrim" -> True]["Data"],
 		{<|"Match" -> "best key lime pie", "Position" -> {{5, 21}}|>},
 		"TestID" -> "ShortStringTest1"
 		]


### PR DESCRIPTION
OptionalLexicalPattern and TextType don't require explicit Whitespace around them anymore.

Closes #85 