### PR TITLE
[Refactor] Move LexicalDispersionPlot to Plots.wl

### DIFF
--- a/LexicalCases/Kernel/LexicalCases.wl
+++ b/LexicalCases/Kernel/LexicalCases.wl
@@ -49,6 +49,7 @@ Begin["`Private`"]
 Needs["LexicalCases`Samples`"]
 Needs["LexicalCases`Utilities`"]
 Needs["LexicalCases`LexicalPattern`"]
+Needs["LexicalCases`Plots`"]
 
 (* Validation *)
 $ValidLexicalTokens = (_TextType|_OptionalToken|_BoundToken|_WordToken)
@@ -687,45 +688,6 @@ WordStemGroups[ds_Dataset] := (GetWordStemCounts[ds] // KeyValueMap[<|"Stem" -> 
 PercentDataset[ds_Dataset, matchcount_Integer] := (ds[
 	All,
 	<|"Matches" -> #Matches, "Percentage" -> Quantity[100. N[((#CountGroup Length[#Matches])/matchcount)], "Percent"]|> &][ReverseSortBy["Percentage"]])
-
-Options[LexicalDispersionPlot] = {
-	AspectRatio -> 1/5,
-	ImageSize -> Large,
-	PlotRange -> All,
-	PlotTheme -> "Scientific",
-	PlotLabel -> "Lexical Dispersion Plot"
-};
-LexicalDispersionPlot[text_String, word_String, opts:OptionsPattern[{LexicalDispersionPlot}]] := LexicalDispersionPlot[text, {word}, opts]
-LexicalDispersionPlot[text_String, words:{__String}, opts:OptionsPattern[{LexicalDispersionPlot}]] := Module[
-	{
-		tokens = Monitor[
-			(* TextWords is slow for what I want it to do, using StringCases instead *)
-			(*TextWords[text]*)
-			StringCases[text, RegularExpression["\\b\\w+\\b"]],
-			Row[{"Tokenizing text",ProgressIndicator[Appearance->"Ellipsis"]}]
-			], textevents, events,
-		rowIndex = AssociationThread[words -> Range[Length[words]]],
-		sparr, ticks
-		},
-		(* 1 \[LongDash] Generate discrete indices for the tokenized text *)
-		textevents = Monitor[PositionIndex[tokens], Row[{"Indexing tokens", ProgressIndicator[Appearance->"Ellipsis"]}]];
-		events = Monitor[
-			KeyTake[words][textevents] // KeyValueMap[Thread[Thread[{rowIndex[#1], #2}] -> 1] &] /* Flatten,
-			Row[{"Generating sparse elements", ProgressIndicator[Appearance->"Ellipsis"]}]
-			];
-		sparr = SparseArray[events, {Length[words], Length[tokens]}];
-		
-		ticks = KeyValueMap[{#2, #1}&, rowIndex];
-		MatrixPlot[
-			sparr,
-			FrameTicks -> {{ticks, None}, {Automatic, None}},
-			AspectRatio -> OptionValue[AspectRatio],
-			ImageSize -> OptionValue[ImageSize],
-			PlotRange -> OptionValue[PlotRange],
-			PlotTheme -> OptionValue[PlotTheme],
-			PlotLabel -> OptionValue[PlotLabel]
-			]
-		]
 
 GenerateDashboard[lps_LexicalSummary, params___] := With[
 	{

--- a/LexicalCases/Kernel/Plots.wl
+++ b/LexicalCases/Kernel/Plots.wl
@@ -1,0 +1,42 @@
+BeginPackage["LexicalCases`Plots`"]
+Begin["`Private`"]
+Options[LexicalCases`LexicalDispersionPlot] = {
+	AspectRatio -> 1/5,
+	ImageSize -> Large,
+	PlotRange -> All,
+	PlotTheme -> "Scientific",
+	PlotLabel -> "Lexical Dispersion Plot"
+};
+LexicalCases`LexicalDispersionPlot[text_String, word_String, opts:OptionsPattern[{LexicalCases`LexicalDispersionPlot}]] := LexicalCases`LexicalDispersionPlot[text, {word}, opts]
+LexicalCases`LexicalDispersionPlot[text_String, words:{__String}, opts:OptionsPattern[{LexicalCases`LexicalDispersionPlot}]] := Module[
+	{
+		tokens = Monitor[
+			(* TextWords is slow for what I want it to do, using StringCases instead *)
+			(*TextWords[text]*)
+			StringCases[text, RegularExpression["\\b\\w+\\b"]],
+			Row[{"Tokenizing text",ProgressIndicator[Appearance->"Ellipsis"]}]
+			], textevents, events,
+		rowIndex = AssociationThread[words -> Range[Length[words]]],
+		sparr, ticks
+		},
+		(* 1 \[LongDash] Generate discrete indices for the tokenized text *)
+		textevents = Monitor[PositionIndex[tokens], Row[{"Indexing tokens", ProgressIndicator[Appearance->"Ellipsis"]}]];
+		events = Monitor[
+			KeyTake[words][textevents] // KeyValueMap[Thread[Thread[{rowIndex[#1], #2}] -> 1] &] /* Flatten,
+			Row[{"Generating sparse elements", ProgressIndicator[Appearance->"Ellipsis"]}]
+			];
+		sparr = SparseArray[events, {Length[words], Length[tokens]}];
+		
+		ticks = KeyValueMap[{#2, #1}&, rowIndex];
+		MatrixPlot[
+			sparr,
+			FrameTicks -> {{ticks, None}, {Automatic, None}},
+			AspectRatio -> OptionValue[AspectRatio],
+			ImageSize -> OptionValue[ImageSize],
+			PlotRange -> OptionValue[PlotRange],
+			PlotTheme -> OptionValue[PlotTheme],
+			PlotLabel -> OptionValue[PlotLabel]
+			]
+		]
+End[]
+EndPackage[]


### PR DESCRIPTION
Moves LexicalDispersionPlot into new Plots.wl Package in the effort to clean up LexicalCases.wl.

Closes #189