### PR TITLE
MassWordToken is never applied

### DIFF
--- a/FaizonZaman/LexicalCases/Kernel/LexicalCases.wl
+++ b/FaizonZaman/LexicalCases/Kernel/LexicalCases.wl
@@ -320,10 +320,10 @@ MassSynonymToken[expr_] := expr /. $SynonymTokenRules
 
 MassTokens[content_Association] := (MassSynonymToken@*MassWordToken@*MassTypeToken[content])
 
-StartContext[content_][a:anchor[seq__], after__] := MassOptionalToken@StringExpression[MassTokens[content]@a, after]
-MiddleContext[content_][before__, a:anchor[seq__], after__] := MassOptionalToken@StringExpression[before, MassTokens[content]@a, after]
-EndContext[content_][before__, a:anchor[seq__]] := MassOptionalToken@StringExpression[before, MassTokens[content]@a]
-SingletonContext[content_][a:anchor[seq__]] := MassOptionalToken@StringExpression[MassTokens[content]@a]
+StartContext[content_][a:anchor[seq__], after__] := MassSynonymToken@MassWordToken@MassOptionalToken@StringExpression[MassTokens[content]@a, after]
+MiddleContext[content_][before__, a:anchor[seq__], after__] := MassSynonymToken@MassWordToken@MassOptionalToken@StringExpression[before, MassTokens[content]@a, after]
+EndContext[content_][before__, a:anchor[seq__]] := MassSynonymToken@MassWordToken@MassOptionalToken@StringExpression[before, MassTokens[content]@a]
+SingletonContext[content_][a:anchor[seq__]] := MassSynonymToken@MassWordToken@MassOptionalToken@StringExpression[MassTokens[content]@a]
 
 TokenPostProcess[expr_] := With[
 	{list = StringExpressionToList@expr},

--- a/FaizonZaman/LexicalCases/ResourceDefinition.nb
+++ b/FaizonZaman/LexicalCases/ResourceDefinition.nb
@@ -2712,7 +2712,7 @@ Cell[BoxData[
  TaggingRules->{},
  CellChangeTimes->{{3.91522334954283*^9, 3.915223351147139*^9}, {
   3.915491425748333*^9, 3.915491426774502*^9}},
- CellLabel->"In[16]:=",
+ CellLabel->"In[6]:=",
  CellID->926712916,ExpressionUUID->"c66c6b20-67c9-4124-89b9-e9a2d883ad93"],
 
 Cell[CellGroupData[{
@@ -3019,9 +3019,9 @@ Cell[BoxData[
                  TagBox[
                   
                   TemplateBox[{
-                   "5.340757`4.986023213522572", "\"s\"", "seconds", 
-                    "\"Seconds\""}, "Quantity", SyntaxForm -> Mod], 
-                  "SummaryItem"]}], "\[SpanFromLeft]"}}, 
+                   "6.2787629999999999999`5.056294485504408", "\"s\"", 
+                    "seconds", "\"Seconds\""}, "Quantity", SyntaxForm -> Mod],
+                   "SummaryItem"]}], "\[SpanFromLeft]"}}, 
              GridBoxAlignment -> {
               "Columns" -> {{Left}}, "Rows" -> {{Automatic}}}, AutoDelete -> 
              False, GridBoxItemSize -> {
@@ -3041,17 +3041,17 @@ Cell[BoxData[
   TestReportObject[<|
    "Title" -> "Test Report: LexicalStructure.wlt", "Aborted" -> False, 
     "TestResults" -> <|
-     1151046358412905487 -> 
+     7362047492108827778 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055212434`15.648685237248666*^9, "SameTest" -> SameQ, 
-         "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
+         3.9416525684116230000000000001`15.64928332615971*^9, "SameTest" -> 
+         SameQ, "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "5364b85b-1311-4b5a-9095-38eef3ad01f7", "TestID" -> 
+         "CreationID" -> "3045aa2b-57e4-46c6-bd4c-fb9db5318829", "TestID" -> 
          "LexicalStructureTest1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/LexicalStructure.wlt", "EvaluationID" -> 
-         "e9487076-c1b6-491e-9448-0ebc8bf4fbea", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/LexicalStructure.wlt", "EvaluationID" -> 
+         "ffcaa3dd-e3da-4634-9c66-cc9ef735f1a5", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalStructure[
             StringExpression[
              Alternatives["computer", "computers"], 
@@ -3079,19 +3079,19 @@ Tests/LexicalStructure.wlt", "EvaluationID" ->
              TextElement[{"Verb"}, <|"GrammaticalUnit" -> "TypeToken"|>]}, <|
             "GrammaticalUnit" -> "StringExpression"|>]], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.00018`2.405787502935298, "CPUTimeUsed" -> 0.00017999999999940286`, 
-         "MemoryUsed" -> 5928, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 250796124417367173 -> 
+         0.000185`2.417686726235008, "CPUTimeUsed" -> 0.0001870000000003813, 
+         "MemoryUsed" -> 5952, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 4467045581974425864 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055225268`15.648685237250083*^9, "SameTest" -> SameQ, 
+         3.941652568423847`15.649283326161056*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "49f76217-e6b2-4d41-966a-45bebf7fa9ee", "TestID" -> 
+         "CreationID" -> "bc749d0e-4f16-4682-83d2-e32f3e2fe0cb", "TestID" -> 
          "ShortStringTest1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/LexicalCases.wlt", "EvaluationID" -> 
-         "58cb2c78-2e6a-4595-b77b-aa0ac0706549", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/LexicalCases.wlt", "EvaluationID" -> 
+         "3b17981f-ece6-4306-a399-21e7e05d3d75", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalCases[
            FaizonZaman`LexicalCases`$SampleSentence, 
             FaizonZaman`LexicalCases`$SampleStringExpression]["Data"]], 
@@ -3102,19 +3102,19 @@ Tests/LexicalCases.wlt", "EvaluationID" ->
          HoldForm[{<|
             "Match" -> "best key lime pie", "Position" -> {{5, 21}}|>}], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         1.432844`6.306713907261328, "CPUTimeUsed" -> 0.1468000000000007, 
-         "MemoryUsed" -> 1207656, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 8038766761279039187 -> 
+         1.444526`6.310240360941881, "CPUTimeUsed" -> 0.14219000000000026`, 
+         "MemoryUsed" -> 1208632, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 6693745743710863926 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055225478`15.648685237250104*^9, "SameTest" -> SameQ, 
+         3.941652568424091`15.649283326161083*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "5ff6b124-1aed-47c6-8c8e-b0274d4e8f3c", "TestID" -> 
+         "CreationID" -> "97e1c567-a9ff-46bc-a545-5cd8de174464", "TestID" -> 
          "LexicalCases-DocExamples-BoundToken-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/LexicalCases.wlt", "EvaluationID" -> 
-         "7748b370-f49f-40e6-89c9-7ebbac04a3ac", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/LexicalCases.wlt", "EvaluationID" -> 
+         "85d6f695-8685-45d7-85e4-31b419fd32ad", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalCases[
            "The great machine whirs. The weak machines sputter.", 
             StringExpression["great ", 
@@ -3124,19 +3124,19 @@ Tests/LexicalCases.wlt", "EvaluationID" ->
          "ExpectedMessages" -> HoldForm[{}], "ActualOutput" -> 
          HoldForm[{<|"Match" -> "great machine", "Position" -> {{5, 17}}|>}], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.004378`3.791790755063905, "CPUTimeUsed" -> 0.004371999999999154, 
-         "MemoryUsed" -> 14032, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 1298978425671804092 -> 
+         0.00451`3.8046915397099546, "CPUTimeUsed" -> 0.004516999999999882, 
+         "MemoryUsed" -> 13872, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 6643067399705885820 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055225628`15.64868523725012*^9, "SameTest" -> SameQ, 
-         "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
+         3.9416525684242570000000000001`15.649283326161099*^9, "SameTest" -> 
+         SameQ, "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "90cef7c0-dfc5-4160-a2ed-0eefa3cece12", "TestID" -> 
+         "CreationID" -> "2c0a9681-f202-4ef4-ae4c-75487b766a82", "TestID" -> 
          "LexicalCases-DocExamples-BoundToken-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/LexicalCases.wlt", "EvaluationID" -> 
-         "f89473c5-4306-494c-8378-89352a63bb28", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/LexicalCases.wlt", "EvaluationID" -> 
+         "30d7a972-234c-443e-ae5a-3c84c19e19a7", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalCases[
            "The great machine whirs. The weak machines sputter.", 
             StringExpression["great ", 
@@ -3146,19 +3146,19 @@ Tests/LexicalCases.wlt", "EvaluationID" ->
          "ExpectedMessages" -> HoldForm[{}], "ActualOutput" -> 
          HoldForm[{<|"Match" -> "great machine", "Position" -> {{5, 17}}|>}], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.004315`3.785495797883222, "CPUTimeUsed" -> 0.004302000000000028, 
+         0.00413`3.766465049488395, "CPUTimeUsed" -> 0.004140000000000477, 
          "MemoryUsed" -> 7608, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 8267559270683908179 -> 
+         "Success", "FailureType" -> None|>], 5286372863470977613 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055225774`15.648685237250138*^9, "SameTest" -> SameQ, 
+         3.941652568424416`15.64928332616112*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "ab98a6e0-9453-489f-bc66-19059fe2dfba", "TestID" -> 
+         "CreationID" -> "1d9b2b95-e8bd-4732-843c-4720f37de592", "TestID" -> 
          "LexicalCases-DocExamples-BoundToken-Test2", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/LexicalCases.wlt", "EvaluationID" -> 
-         "ff100956-142c-4b7c-b1f4-ea6c9c181807", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/LexicalCases.wlt", "EvaluationID" -> 
+         "6320876d-fef2-41b1-bfa3-f0651b612cb8", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalCases[
            "The great machine whirs. The weak machines sputter.", 
             StringExpression["weak ", 
@@ -3168,19 +3168,19 @@ Tests/LexicalCases.wlt", "EvaluationID" ->
           "ExpectedMessages" -> HoldForm[{}], "ActualOutput" -> 
          HoldForm[{<|"Match" -> "weak machines", "Position" -> {{30, 42}}|>}],
           "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.004406`3.7945594906467406, "CPUTimeUsed" -> 0.00436000000000103, 
+         0.004186`3.7723142218346615, "CPUTimeUsed" -> 0.004220000000001001, 
          "MemoryUsed" -> 8056, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 6824406522018861239 -> 
+         "Success", "FailureType" -> None|>], 308812363314278494 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055225916`15.648685237250154*^9, "SameTest" -> SameQ, 
-         "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
+         3.9416525684245670000000000001`15.649283326161134*^9, "SameTest" -> 
+         SameQ, "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "9a72a6c2-20a8-4150-86df-4fecb0df3947", "TestID" -> 
+         "CreationID" -> "6d563f0d-8eef-4c86-968d-f974372d1926", "TestID" -> 
          "LexicalCases-DocExamples-BoundToken-Test3", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/LexicalCases.wlt", "EvaluationID" -> 
-         "98b95a13-a8c8-4e15-8942-c86771c9bb49", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/LexicalCases.wlt", "EvaluationID" -> 
+         "8034f7de-b94e-405d-9cea-86fcfdba8bc4", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalCases[
            "The great machine whirs. The weak machines sputter.", 
             StringExpression["weak ", 
@@ -3190,19 +3190,19 @@ Tests/LexicalCases.wlt", "EvaluationID" ->
           "ExpectedMessages" -> HoldForm[{}], "ActualOutput" -> 
          HoldForm[{<|"Match" -> "weak machines", "Position" -> {{30, 42}}|>}],
           "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.004905`3.8411540095479593, "CPUTimeUsed" -> 0.0047199999999998354`,
-          "MemoryUsed" -> 8552, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 2340093621166438648 -> 
+         0.004252`3.779108253683253, "CPUTimeUsed" -> 0.004260000000000375, 
+         "MemoryUsed" -> 8616, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 8239482898412596007 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055226053`15.648685237250168*^9, "SameTest" -> SameQ, 
+         3.941652568424711`15.64928332616115*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "4df116aa-0a58-4432-ad2b-3dd4f888180c", "TestID" -> 
+         "CreationID" -> "3a0dd525-0c6f-4e0d-81ec-45d36c206f77", "TestID" -> 
          "LexicalCases-DocExamples-BoundToken-Test4", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/LexicalCases.wlt", "EvaluationID" -> 
-         "80def84a-2e2f-4350-9c94-4ef83fb3c574", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/LexicalCases.wlt", "EvaluationID" -> 
+         "946c9c01-a8a1-4143-a840-23775965d4f8", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalCases["He was number 1!", 
             StringExpression["number ", 
              FaizonZaman`LexicalCases`BoundToken[DigitCharacter]]]["Data"]], 
@@ -3211,19 +3211,19 @@ Tests/LexicalCases.wlt", "EvaluationID" ->
          "ExpectedMessages" -> HoldForm[{}], "ActualOutput" -> 
          HoldForm[{<|"Match" -> "number 1", "Position" -> {{8, 15}}|>}], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.004023`3.7550650304032556, "CPUTimeUsed" -> 0.0040300000000002, 
+         0.004413`3.7952489252791866, "CPUTimeUsed" -> 0.004420999999999786, 
          "MemoryUsed" -> 7808, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 2767201573043944099 -> 
+         "Success", "FailureType" -> None|>], 112048745854094428 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055226192`15.648685237250184*^9, "SameTest" -> SameQ, 
-         "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
+         3.9416525684248590000000000001`15.649283326161168*^9, "SameTest" -> 
+         SameQ, "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "5c8ace5c-dd62-4791-a235-e5904cd1a4b5", "TestID" -> 
+         "CreationID" -> "825781fb-81d5-4a89-8e75-e772c0cd408a", "TestID" -> 
          "LexicalCases-DocExamples-BoundToken-Test5", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/LexicalCases.wlt", "EvaluationID" -> 
-         "15b60fc8-ebe7-45d6-ba4d-034d02bf6006", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/LexicalCases.wlt", "EvaluationID" -> 
+         "e295c57c-69e2-4f41-a2c7-886aaaebd905", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalCases[
            "The great machine whirs. The weak machines sputter.", 
             StringExpression[
@@ -3237,19 +3237,19 @@ Tests/LexicalCases.wlt", "EvaluationID" ->
          HoldForm[{<|"Match" -> "great machine", "Position" -> {{5, 17}}|>, <|
             "Match" -> "weak machines", "Position" -> {{30, 42}}|>}], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.00534`3.878056254860548, "CPUTimeUsed" -> 0.005325000000000024, 
-         "MemoryUsed" -> 28008, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 1457089740556019864 -> 
+         0.005401`3.8829891751131878, "CPUTimeUsed" -> 0.005411000000000499, 
+         "MemoryUsed" -> 27912, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 39160000590931452 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055226365`15.648685237250202*^9, "SameTest" -> SameQ, 
+         3.941652568425045`15.64928332616119*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "bac39368-9f0c-403b-99fc-9341c94150c0", "TestID" -> 
+         "CreationID" -> "edb4e6c8-21d6-4e5a-ac25-4f8657fd4d49", "TestID" -> 
          "LexicalCases-DocExamples-WordToken-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/LexicalCases.wlt", "EvaluationID" -> 
-         "8324aad8-7925-4384-9b7b-eedcd36d4e38", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/LexicalCases.wlt", "EvaluationID" -> 
+         "48a24d92-9afa-4e25-b55a-8aa63c8e2554", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalCases[
            FaizonZaman`LexicalCases`$SampleParagraph, 
             StringExpression[
@@ -3265,19 +3265,19 @@ Tests/LexicalCases.wlt", "EvaluationID" ->
             "Match" -> "That blank screen", "Position" -> {{176, 192}}|>, <|
             "Match" -> "with the screen", "Position" -> {{480, 494}}|>}], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.005023`3.851478175991541, "CPUTimeUsed" -> 0.0045999999999999375`, 
-         "MemoryUsed" -> 14848, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 7852814752794307313 -> 
+         0.00787`4.046489730191059, "CPUTimeUsed" -> 0.004844999999999544, 
+         "MemoryUsed" -> 14688, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 2182569609262038572 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055226506`15.64868523725022*^9, "SameTest" -> SameQ, 
+         3.941652568425195`15.649283326161205*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "f512859e-8ee0-4fb8-8506-82c5f94968a8", "TestID" -> 
+         "CreationID" -> "5beb035f-10fa-4ea0-bf09-51ad30d8e2c6", "TestID" -> 
          "LexicalCases-DocExamples-WordToken-Test2", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/LexicalCases.wlt", "EvaluationID" -> 
-         "c60b80a8-a575-4554-8729-c7dc64776977", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/LexicalCases.wlt", "EvaluationID" -> 
+         "3f1e40f6-6e62-436e-82cb-7e6c040320d4", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalCases[
            FaizonZaman`LexicalCases`$SampleParagraph, 
             StringExpression[
@@ -3296,20 +3296,20 @@ Tests/LexicalCases.wlt", "EvaluationID" ->
             "Match" -> "That blank screen", "Position" -> {{176, 192}}|>, <|
             "Match" -> "would end with the screen", 
              "Position" -> {{470, 494}}|>}], "ActualMessages" -> {}, 
-         "AbsoluteTimeUsed" -> 0.005053`3.8540642960702223, "CPUTimeUsed" -> 
-         0.005061999999999678, "MemoryUsed" -> 13496, 
+         "AbsoluteTimeUsed" -> 0.005142`3.8616470701388357, "CPUTimeUsed" -> 
+         0.005148999999999404, "MemoryUsed" -> 13432, 
          "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 1787374556187748286 -> 
+         None|>], 417563417626590212 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055226669`15.648685237250236*^9, "SameTest" -> SameQ, 
+         3.94165256842536`15.649283326161223*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "8a94c509-7a62-4373-915d-cde9e43dfbf2", "TestID" -> 
+         "CreationID" -> "ad29f833-4ae6-44df-9ab0-2f9fd9d56013", "TestID" -> 
          "LexicalCases-DocExamples-WordToken-Test3", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/LexicalCases.wlt", "EvaluationID" -> 
-         "6b264dc3-08f0-43b2-a6b7-fee3ba266118", "Input" -> HoldForm[Length[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/LexicalCases.wlt", "EvaluationID" -> 
+         "a19c152e-74b4-40f3-8683-52de39fb2e5c", "Input" -> HoldForm[Length[
              Composition[Join, Flatten][{
                FaizonZaman`LexicalCases`LexicalCases[
                FaizonZaman`LexicalCases`$SampleParagraph, 
@@ -3331,19 +3331,19 @@ Tests/LexicalCases.wlt", "EvaluationID" ->
               True]["Data"]]], "ExpectedOutput" -> HoldForm[True], 
          "ExpectedMessages" -> HoldForm[{}], "ActualOutput" -> HoldForm[True],
           "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.016942`4.3794796752371505, "CPUTimeUsed" -> 0.01689200000000035, 
-         "MemoryUsed" -> 18232, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 3237472131926533386 -> 
+         0.016796`4.375720863797896, "CPUTimeUsed" -> 0.01686199999999971, 
+         "MemoryUsed" -> 18168, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 9051416689422506145 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055226835`15.648685237250254*^9, "SameTest" -> SameQ, 
+         3.941652568425539`15.64928332616124*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "736e81eb-77c3-4b6a-a733-141b8c7df022", "TestID" -> 
+         "CreationID" -> "238a5c69-64bc-4d79-9464-a025c6a360b9", "TestID" -> 
          "LexicalCases-DocExamples-OptionalToken-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/LexicalCases.wlt", "EvaluationID" -> 
-         "c6f9af3b-1ea8-4c4b-971d-8f2b935342f1", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/LexicalCases.wlt", "EvaluationID" -> 
+         "fa4eefb8-812a-493d-8cd3-ade716f017d4", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalCases[
            "this is a cool string. this is a string.", 
             StringExpression["this is a", 
@@ -3357,19 +3357,19 @@ Tests/LexicalCases.wlt", "EvaluationID" ->
             "Match" -> "this is a cool string", "Position" -> {{1, 21}}|>, <|
             "Match" -> "this is a string", "Position" -> {{24, 39}}|>}], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.004574`3.810811158102719, "CPUTimeUsed" -> 0.00461499999999937, 
-         "MemoryUsed" -> 9656, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 2642243449429833648 -> 
+         0.00449`3.8027613388353174, "CPUTimeUsed" -> 0.00449500000000036, 
+         "MemoryUsed" -> 9816, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 5945893656793066161 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055227007`15.648685237250275*^9, "SameTest" -> SameQ, 
+         3.941652568425719`15.649283326161262*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "374085dc-28c5-41d4-9075-4a57aa3ec65b", "TestID" -> 
+         "CreationID" -> "88dfebb6-8d41-4a67-b8da-df90f6ae65ee", "TestID" -> 
          "LexicalCases-DocExamples-BoundToken-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/LexicalCases.wlt", "EvaluationID" -> 
-         "ba12b688-ea8c-4230-b73b-2ee262deb05f", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/LexicalCases.wlt", "EvaluationID" -> 
+         "bdc87c51-3db5-48d2-b17f-23ea7173ef7f", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalCases[
            FaizonZaman`LexicalCases`$SampleParagraph, 
             FaizonZaman`LexicalCases`BoundToken[
@@ -3388,20 +3388,20 @@ Tests/LexicalCases.wlt", "EvaluationID" ->
              "Position" -> {{266, 296}}|>, <|
             "Match" -> "eight hours he was prepared", 
              "Position" -> {{404, 430}}|>}], "ActualMessages" -> {}, 
-         "AbsoluteTimeUsed" -> 0.006389`3.9559478859641293, "CPUTimeUsed" -> 
-         0.006463999999999359, "MemoryUsed" -> 10776, 
+         "AbsoluteTimeUsed" -> 0.006628`3.971897497579293, "CPUTimeUsed" -> 
+         0.00666000000000011, "MemoryUsed" -> 10776, 
          "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 1864374057644639507 -> 
+         None|>], 9072621057043268309 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055227156`15.648685237250293*^9, "SameTest" -> MatchQ, 
+         3.941652568425887`15.649283326161278*^9, "SameTest" -> MatchQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "dd4b9523-7748-4723-8093-f5e6c16cf6e4", "TestID" -> 
+         "CreationID" -> "04a5898a-a717-4a8c-af3d-c2fb9e125233", "TestID" -> 
          "LexicalCases-DocExamples-BoundToken-Test2", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/LexicalCases.wlt", "EvaluationID" -> 
-         "8791523f-18cc-490c-a3c8-3d4758eec689", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/LexicalCases.wlt", "EvaluationID" -> 
+         "664427f5-7ebb-47d4-8dd7-44530c909d89", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalCases[
            "a nice car is good.", FaizonZaman`LexicalCases`BoundToken[
               Pattern[$CellContext`w, 
@@ -3416,8 +3416,8 @@ Tests/LexicalCases.wlt", "EvaluationID" ->
              "MessageParameters" -> {}, "ConfirmationType" -> "ConfirmQuiet", 
              "Expression" :> Hold[
                StringCases[
-               FaizonZaman`LexicalCases`Private`s$21172, 
-                FaizonZaman`LexicalCases`Private`rx$21172, IgnoreCase -> 
+               FaizonZaman`LexicalCases`Private`s$20753, 
+                FaizonZaman`LexicalCases`Private`rx$20753, IgnoreCase -> 
                 OptionValue[
                  FaizonZaman`LexicalCases`LexicalCases, {}, IgnoreCase], 
                 Overlaps -> 
@@ -3426,8 +3426,8 @@ Tests/LexicalCases.wlt", "EvaluationID" ->
              "Information" -> "Message issued while calling StringCases", 
              "HeldExpression" -> Hold[
                StringCases[
-               FaizonZaman`LexicalCases`Private`s$21172, 
-                FaizonZaman`LexicalCases`Private`rx$21172, IgnoreCase -> 
+               FaizonZaman`LexicalCases`Private`s$20753, 
+                FaizonZaman`LexicalCases`Private`rx$20753, IgnoreCase -> 
                 OptionValue[
                  FaizonZaman`LexicalCases`LexicalCases, {}, IgnoreCase], 
                 Overlaps -> 
@@ -3442,19 +3442,19 @@ Tests/LexicalCases.wlt", "EvaluationID" ->
                  StringExpression[WordBoundary, 
                   Repeated[WordCharacter], WordBoundary]]]]|>]], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.031142`4.643861498198711, "CPUTimeUsed" -> 0.031150000000000233`, 
-         "MemoryUsed" -> 8872, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 1226921975273791018 -> 
+         0.032737`4.665553876232852, "CPUTimeUsed" -> 0.032267000000000046`, 
+         "MemoryUsed" -> 8768, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 8138041654009908707 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055227316`15.648685237250309*^9, "SameTest" -> SameQ, 
+         3.941652568426062`15.6492833261613*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "6c9b4cc3-b685-474e-92c7-8d4f89329c1b", "TestID" -> 
+         "CreationID" -> "28f02a79-d28f-48b7-b1a3-d2029eeeac98", "TestID" -> 
          "LexicalCases-DocExamples-TypeToken-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/LexicalCases.wlt", "EvaluationID" -> 
-         "86497712-2e36-4d7d-8734-550a6c5864ef", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/LexicalCases.wlt", "EvaluationID" -> 
+         "0d8d08f3-43c1-44e3-b3da-215cadf7b444", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalCases[
            FaizonZaman`LexicalCases`$SampleParagraph, StringExpression[
               Pattern[$CellContext`adjective, 
@@ -3467,19 +3467,19 @@ Tests/LexicalCases.wlt", "EvaluationID" ->
          HoldForm[{<|
             "Match" -> "blank", "Position" -> {{146, 157}, {181, 192}}|>}], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         1.739635`6.390973134554627, "CPUTimeUsed" -> 1.5667170000000006`, 
-         "MemoryUsed" -> 34904176, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 4342132244726376048 -> 
+         2.730022`6.58668114466766, "CPUTimeUsed" -> 2.4359910000000005`, 
+         "MemoryUsed" -> 52048888, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 7735113545884152269 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.93622805522745`15.648685237250321*^9, "SameTest" -> SameQ, 
+         3.94165256842621`15.649283326161317*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "b3652566-702d-472a-8716-4e41496b1ce1", "TestID" -> 
+         "CreationID" -> "9b301229-b6bf-466a-9b4c-ba652d2ff36e", "TestID" -> 
          "LexicalCases-DocExamples-TypeToken-Test2", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/LexicalCases.wlt", "EvaluationID" -> 
-         "dbe44340-fc9c-49d2-8bef-b5a6d2781074", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/LexicalCases.wlt", "EvaluationID" -> 
+         "018279ed-f4de-4ad3-ac3b-59a70d21c967", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalCases[
            FaizonZaman`LexicalCases`$SampleParagraph, StringExpression[
               Pattern[$CellContext`adjectiveOrDeterminer, 
@@ -3495,19 +3495,19 @@ Tests/LexicalCases.wlt", "EvaluationID" ->
             "Match" -> "blank", "Position" -> {{146, 157}, {181, 192}}|>, <|
             "Match" -> "the", "Position" -> {{485, 494}}|>}], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.027122`4.583836709462776, "CPUTimeUsed" -> 0.05773299999999981, 
-         "MemoryUsed" -> 28776, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 4712270261833686497 -> 
+         0.021911`4.491177196687603, "CPUTimeUsed" -> 0.053589999999999804`, 
+         "MemoryUsed" -> 28840, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 2953953235522807985 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055227615`15.648685237250342*^9, "SameTest" -> SameQ, 
+         3.941652568426393`15.649283326161335*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "fc4ead3e-145b-4e23-a7f1-b3c8d47913a2", "TestID" -> 
+         "CreationID" -> "129f082e-ceb3-4f65-8237-b8e745670b07", "TestID" -> 
          "LexicalCases-DocExamples-SynonymToken-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/LexicalCases.wlt", "EvaluationID" -> 
-         "29becaf9-6a0f-4ce1-ac7e-44336780a2a8", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/LexicalCases.wlt", "EvaluationID" -> 
+         "8551f4d7-c78f-4a38-9822-1dcd45fb91e0", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalCases[
            "cool person. nice mortal. great soul.", 
             StringExpression[
@@ -3522,39 +3522,39 @@ Tests/LexicalCases.wlt", "EvaluationID" ->
             "Match" -> "nice mortal", "Position" -> {{14, 24}}|>, <|
             "Match" -> "great soul", "Position" -> {{27, 36}}|>}], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         1.876688`6.423907074853349, "CPUTimeUsed" -> 1.8414260000000002`, 
-         "MemoryUsed" -> 162168056, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 2870872620639729456 -> 
+         1.86399`6.420958575937688, "CPUTimeUsed" -> 1.8107799999999976`, 
+         "MemoryUsed" -> 162167944, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 4930815828353883015 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055240061`15.648685237251716*^9, "SameTest" -> SameQ, 
+         3.941652568437853`15.649283326162601*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "a763b05b-f606-4850-bb6c-bacd0c0a3f0a", "TestID" -> 
+         "CreationID" -> "caee9f7c-2752-4a44-a030-9257e2d59f38", "TestID" -> 
          "LexicalMapTest1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Abstractions.wlt", "EvaluationID" -> 
-         "2ca4cbb4-6e67-4c88-85ed-d289382f944d", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Abstractions.wlt", "EvaluationID" -> 
+         "f575f0ee-80fd-4359-8f2f-55436daa1820", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalMap[ToUpperCase, "This is cool", 
             FaizonZaman`LexicalCases`BoundToken[
              FaizonZaman`LexicalCases`TypeToken[
               Alternatives["Adjective", "Verb"]]]]], "ExpectedOutput" -> 
          HoldForm["This IS COOL"], "ExpectedMessages" -> HoldForm[{}], 
          "ActualOutput" -> HoldForm["This IS COOL"], "ActualMessages" -> {}, 
-         "AbsoluteTimeUsed" -> 0.006123`3.937479257267727, "CPUTimeUsed" -> 
-         0.005361000000000615, "MemoryUsed" -> 5704, 
+         "AbsoluteTimeUsed" -> 0.0069`3.9893640885692494, "CPUTimeUsed" -> 
+         0.005785999999998737, "MemoryUsed" -> 5640, 
          "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 3755930452717230419 -> 
+         None|>], 8041696850144999069 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055240223`15.648685237251733*^9, "SameTest" -> SameQ, 
+         3.941652568438059`15.649283326162623*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "314a11d4-ff4b-4ad9-bc89-8db2d857ba7a", "TestID" -> 
+         "CreationID" -> "732cd6d8-a464-4dab-b3d9-d920666062d9", "TestID" -> 
          "LexicalMapTest2", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Abstractions.wlt", "EvaluationID" -> 
-         "7b5a2c9f-1b72-40ef-ae87-4a6f7289b874", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Abstractions.wlt", "EvaluationID" -> 
+         "936aad91-85af-4b63-b86e-18207230290e", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalMap[
             RightComposition[StringReverse, ToUpperCase], "This is cool", 
             FaizonZaman`LexicalCases`BoundToken[
@@ -3562,20 +3562,20 @@ Tests/Abstractions.wlt", "EvaluationID" ->
               Alternatives["Adjective", "Verb"]]]]], "ExpectedOutput" -> 
          HoldForm["This SI LOOC"], "ExpectedMessages" -> HoldForm[{}], 
          "ActualOutput" -> HoldForm["This SI LOOC"], "ActualMessages" -> {}, 
-         "AbsoluteTimeUsed" -> 0.005953`3.9252508803837447, "CPUTimeUsed" -> 
-         0.005232999999998711, "MemoryUsed" -> 5888, 
+         "AbsoluteTimeUsed" -> 0.006173`3.941011274799103, "CPUTimeUsed" -> 
+         0.005378000000002103, "MemoryUsed" -> 5888, 
          "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 8677634797974480948 -> 
+         None|>], 322466845752533450 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.93622805524036`15.648685237251746*^9, "SameTest" -> SameQ, 
+         3.941652568438217`15.649283326162639*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "7577fc3d-bf46-4e14-b64a-e007b6b5f659", "TestID" -> 
+         "CreationID" -> "7d3c7c73-51ca-4143-9189-c101b2abed18", "TestID" -> 
          "LexicalMapTest3", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Abstractions.wlt", "EvaluationID" -> 
-         "05bb9d00-fa2d-4697-a903-7b6d6b9de48a", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Abstractions.wlt", "EvaluationID" -> 
+         "9d6f6b3f-6c15-40ff-a255-5ca6f3563654", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalMap[
            "**" <> # <> "**"& , "This is cool", 
             FaizonZaman`LexicalCases`BoundToken[
@@ -3584,19 +3584,19 @@ Tests/Abstractions.wlt", "EvaluationID" ->
          HoldForm["This **is** **cool**"], "ExpectedMessages" -> HoldForm[{}],
           "ActualOutput" -> HoldForm["This **is** **cool**"], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.005763`3.9111636174133477, "CPUTimeUsed" -> 0.005121999999998295, 
-         "MemoryUsed" -> 5888, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 1899201089673174961 -> 
+         0.00618`3.9415034729208096, "CPUTimeUsed" -> 0.005418999999999841, 
+         "MemoryUsed" -> 5768, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 8579059752606972407 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055240494`15.648685237251764*^9, "SameTest" -> SameQ, 
+         3.941652568438366`15.649283326162656*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "a44e6669-1c10-4781-b73f-9c8ae43217b2", "TestID" -> 
+         "CreationID" -> "64705c99-4f0b-4177-afe5-378aab411f94", "TestID" -> 
          "LexicalMapTest4", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Abstractions.wlt", "EvaluationID" -> 
-         "904b31ee-3031-4162-9667-484397018b14", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Abstractions.wlt", "EvaluationID" -> 
+         "5fb9599c-0498-4328-8872-5c4908c84c72", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalMap[
            "**" <> # <> "**"& , "This is cool", 
             FaizonZaman`LexicalCases`BoundToken[
@@ -3605,38 +3605,39 @@ Tests/Abstractions.wlt", "EvaluationID" ->
          HoldForm["This **is** **cool**"], "ExpectedMessages" -> HoldForm[{}],
           "ActualOutput" -> HoldForm["This **is** **cool**"], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.005146`3.8619847797063196, "CPUTimeUsed" -> 0.004535000000000622, 
+         0.00566`3.9033314290202656, "CPUTimeUsed" -> 0.005008999999999375, 
          "MemoryUsed" -> 4480, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 4115248257641464317 -> 
+         "Success", "FailureType" -> None|>], 5222135392752475867 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055240653`15.648685237251781*^9, "SameTest" -> SameQ, 
+         3.941652568438542`15.649283326162672*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "94aca0a0-294e-4da5-8244-f9ee25180875", "TestID" -> 
+         "CreationID" -> "c2ab8aab-bb0d-44ce-8345-96a4b277478a", "TestID" -> 
          "LexigramCountTest1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Abstractions.wlt", "EvaluationID" -> 
-         "8299d6dc-bf46-4a79-9940-1a5aab8f5729", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Abstractions.wlt", "EvaluationID" -> 
+         "bd42affd-3a02-4a83-bd9c-e87bb2a294e5", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexigramCount[
             StringExpression["Alice ", 
              FaizonZaman`LexicalCases`TypeToken["Verb"], 
              FaizonZaman`LexicalCases`WordToken[1]]]], "ExpectedOutput" -> 
          HoldForm[3], "ExpectedMessages" -> HoldForm[{}], "ActualOutput" -> 
          HoldForm[3], "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000122`2.236874828506738, "CPUTimeUsed" -> 0.0001230000000003173, 
-         "MemoryUsed" -> 4048, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 7833335533179527811 -> 
+         0.000153`2.3352064286495926, "CPUTimeUsed" -> 
+         0.00015400000000020952`, "MemoryUsed" -> 4048, 
+         "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
+         None|>], 4953254132395351482 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055240785`15.648685237251797*^9, "SameTest" -> SameQ, 
-         "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
+         3.9416525684386890000000000001`15.64928332616269*^9, "SameTest" -> 
+         SameQ, "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "c9f8efbe-61fa-44ab-8255-4be8ec7be1d6", "TestID" -> 
+         "CreationID" -> "118fe518-ee92-456a-8094-eb87fe651fcd", "TestID" -> 
          "LexigramCountTest2", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Abstractions.wlt", "EvaluationID" -> 
-         "4f942bfc-2051-4199-af8a-685351c583d6", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Abstractions.wlt", "EvaluationID" -> 
+         "36d8e8de-1aad-41d5-a22d-e1f16579a291", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexigramCount[
             StringExpression["Alice ", 
              FaizonZaman`LexicalCases`TypeToken["Verb"], 
@@ -3646,19 +3647,19 @@ Tests/Abstractions.wlt", "EvaluationID" ->
            Interval[{3, 4}]], "ExpectedMessages" -> HoldForm[{}], 
          "ActualOutput" -> HoldForm[
            Interval[{3, 4}]], "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.001189`3.225696852450683, "CPUTimeUsed" -> 0.00036799999999992394`,
-          "MemoryUsed" -> 4544, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 8090295207925700503 -> 
+         0.000471`2.82353590496089, "CPUTimeUsed" -> 0.000321000000001348, 
+         "MemoryUsed" -> 4544, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 8489871958917406551 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055240909`15.648685237251806*^9, "SameTest" -> SameQ, 
+         3.94165256843883`15.649283326162708*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "6c56b9ad-aae8-4aeb-a41f-9b78fa71f006", "TestID" -> 
+         "CreationID" -> "c4e7d025-ef00-4d6b-a5e3-92a59b0422af", "TestID" -> 
          "LexigramCountTest3", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Abstractions.wlt", "EvaluationID" -> 
-         "218da42a-c0f8-43d1-a297-72e984016e0e", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Abstractions.wlt", "EvaluationID" -> 
+         "a9d54f38-51a4-43a9-bc7f-febed7fa6b73", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexigramCount[
             StringExpression[
              FaizonZaman`LexicalCases`TypeToken["Adjective"], "hello", 
@@ -3668,19 +3669,19 @@ Tests/Abstractions.wlt", "EvaluationID" ->
            Interval[{2, 3}]], "ExpectedMessages" -> HoldForm[{}], 
          "ActualOutput" -> HoldForm[
            Interval[{2, 3}]], "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000239`2.528912898780129, "CPUTimeUsed" -> 0.00023900000000054433`,
-          "MemoryUsed" -> 3648, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 9215872555346289706 -> 
+         0.000218`2.488971491436599, "CPUTimeUsed" -> 0.00021799999999849717`,
+          "MemoryUsed" -> 3752, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 6592181290596033303 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055241059`15.648685237251824*^9, "SameTest" -> SameQ, 
-         "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
+         3.9416525684389700000000000001`15.64928332616272*^9, "SameTest" -> 
+         SameQ, "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "48329ef3-e58b-4e69-b09c-902ea7151e34", "TestID" -> 
+         "CreationID" -> "94434b4a-de51-4eee-8a40-8e25fa3a0931", "TestID" -> 
          "LexigramCountTest4", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Abstractions.wlt", "EvaluationID" -> 
-         "28122e33-a0bb-48e7-a623-4b81b3efb0dd", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Abstractions.wlt", "EvaluationID" -> 
+         "458ed02f-5bc3-42ee-8d1d-4dd885841717", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexigramCount[
             StringExpression[
              FaizonZaman`LexicalCases`TypeToken["Adjective"], "hello", 
@@ -3692,37 +3693,38 @@ Tests/Abstractions.wlt", "EvaluationID" ->
            Interval[{2, 4}]], "ExpectedMessages" -> HoldForm[{}], 
          "ActualOutput" -> HoldForm[
            Interval[{2, 4}]], "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000425`2.7789039278823053, "CPUTimeUsed" -> 0.0004259999999991493, 
-         "MemoryUsed" -> 3904, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 1240171017377671387 -> 
+         0.0004370000000000001`2.790996434802416, "CPUTimeUsed" -> 
+         0.00043699999999979866`, "MemoryUsed" -> 3960, 
+         "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
+         None|>], 5928518352032832196 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.93622805525411`15.648685237253265*^9, "SameTest" -> SameQ, 
+         3.941652568451311`15.649283326164081*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "5f61edc8-176e-45a3-a42e-4b3c9c9de195", "TestID" -> 
+         "CreationID" -> "22a4d797-e4f6-4961-a37e-2f5e2bc1fd4d", "TestID" -> 
          "LexicalPatternQTest1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Validation.wlt", "EvaluationID" -> 
-         "3f0f800a-b187-40b4-8da5-92487ea62e4c", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Validation.wlt", "EvaluationID" -> 
+         "c2cf9c08-3ad3-4b39-98fb-357ccf8ab15d", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalPatternQ[
            FaizonZaman`LexicalCases`$SampleStringExpression]], 
          "ExpectedOutput" -> HoldForm[True], "ExpectedMessages" -> 
          HoldForm[{}], "ActualOutput" -> HoldForm[True], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.00008`2.0536049848239375, "CPUTimeUsed" -> 0.00007999999999874774, 
-         "MemoryUsed" -> 3400, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 7290162729857297187 -> 
+         0.000094`2.1236428514316925, "CPUTimeUsed" -> 0.00009399999999892827,
+          "MemoryUsed" -> 3400, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 6822546096943165455 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055254325`15.648685237253286*^9, "SameTest" -> SameQ, 
+         3.94165256845152`15.649283326164106*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "b4600804-85c7-484e-9377-9ebf87086b59", "TestID" -> 
+         "CreationID" -> "5ca835b3-e7a0-4a3a-9353-c0ae7d9f7661", "TestID" -> 
          "LexicalPatternQ-UnvaluedSymbols-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Validation.wlt", "EvaluationID" -> 
-         "a9af6b2f-deaf-40b7-acd9-641372a78ee2", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Validation.wlt", "EvaluationID" -> 
+         "db32f475-82bc-4f86-b4df-11064634781c", "Input" -> HoldForm[
            FailureQ[
             FaizonZaman`LexicalCases`LexicalPatternQ[
              StringExpression["Alice", $CellContext`xxx, 
@@ -3730,20 +3732,20 @@ Tests/Validation.wlt", "EvaluationID" ->
          "ExpectedOutput" -> HoldForm[True], "ExpectedMessages" -> 
          HoldForm[{}], "ActualOutput" -> HoldForm[True], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000112`2.1997330205021712, "CPUTimeUsed" -> 
-         0.00011199999999966792`, "MemoryUsed" -> 4528, 
+         0.000119`2.2260619592245243, "CPUTimeUsed" -> 
+         0.00011899999999975819`, "MemoryUsed" -> 4528, 
          "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 3272574199267405733 -> 
+         None|>], 3452914156035574024 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055254499`15.648685237253307*^9, "SameTest" -> SameQ, 
+         3.941652568451693`15.649283326164124*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "b8813afd-4de3-4d99-b636-f6694ccbbfe7", "TestID" -> 
+         "CreationID" -> "9e2712ad-1213-4492-8a59-9c3c5f92d7a2", "TestID" -> 
          "LexicalPatternQ-BoundToken-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Validation.wlt", "EvaluationID" -> 
-         "e5a6a7ed-9595-48be-9714-8e06389ca476", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Validation.wlt", "EvaluationID" -> 
+         "bd7c1b94-f670-45ff-8fce-0ffa30a850ac", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalPatternQ[
             StringExpression[
              Alternatives["great", "weak"], 
@@ -3751,135 +3753,135 @@ Tests/Validation.wlt", "EvaluationID" ->
               Alternatives["machine", "machines"]]]]], "ExpectedOutput" -> 
          HoldForm[True], "ExpectedMessages" -> HoldForm[{}], "ActualOutput" -> 
          HoldForm[True], "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000185`2.417686726235008, "CPUTimeUsed" -> 0.00018599999999935335`,
-          "MemoryUsed" -> 3464, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 6652430387529252079 -> 
+         0.000181`2.4081935727011787, "CPUTimeUsed" -> 
+         0.00018099999999954264`, "MemoryUsed" -> 3464, 
+         "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
+         None|>], 5247263513186225746 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055254632`15.648685237253321*^9, "SameTest" -> SameQ, 
+         3.941652568451828`15.64928332616414*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "7688eb3e-4ded-469c-96c6-06fc520c1b17", "TestID" -> 
+         "CreationID" -> "08bca045-ac38-43b7-af5b-7b23dfa8c788", "TestID" -> 
          "LexicalPatternQ-BoundToken-Test2", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Validation.wlt", "EvaluationID" -> 
-         "4a3e287b-23de-4ac7-8c14-0d8c05643f31", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Validation.wlt", "EvaluationID" -> 
+         "d028cbd7-8cdd-4dae-a6db-a2702506d456", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalPatternQ[
             StringExpression["weak", 
              FaizonZaman`LexicalCases`BoundToken["machines"]]]], 
          "ExpectedOutput" -> HoldForm[True], "ExpectedMessages" -> 
          HoldForm[{}], "ActualOutput" -> HoldForm[True], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000118`2.222397005138115, "CPUTimeUsed" -> 0.00011900000000153454`,
-          "MemoryUsed" -> 3520, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 2448430130431660673 -> 
+         0.000124`2.243936682994229, "CPUTimeUsed" -> 0.0001239999999995689, 
+         "MemoryUsed" -> 3584, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 8946601301110794291 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055254762`15.648685237253337*^9, "SameTest" -> SameQ, 
+         3.94165256845196`15.649283326164154*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "f7ae82c9-ecd0-451c-aa17-17b68ae36460", "TestID" -> 
+         "CreationID" -> "6a7d564a-4bc1-4a4d-ad06-97c4ddaa7e9c", "TestID" -> 
          "LexicalPatternQ-BoundToken-Test3", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Validation.wlt", "EvaluationID" -> 
-         "4ca2996f-4bb0-4f6c-8204-2251b7aa318d", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Validation.wlt", "EvaluationID" -> 
+         "d2a2bf4a-1a4e-48df-8915-0472f5990613", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalPatternQ[
             StringExpression["weak", 
              FaizonZaman`LexicalCases`BoundToken[
               RegularExpression["\\w+"]]]]], "ExpectedOutput" -> 
          HoldForm[True], "ExpectedMessages" -> HoldForm[{}], "ActualOutput" -> 
          HoldForm[True], "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000121`2.233300368148444, "CPUTimeUsed" -> 0.00012100000000003774`,
+         0.000128`2.257724967479862, "CPUTimeUsed" -> 0.00012900000000115597`,
           "MemoryUsed" -> 3464, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 8371173631780887560 -> 
+         "Success", "FailureType" -> None|>], 5279049013091164431 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055254891`15.64868523725335*^9, "SameTest" -> SameQ, 
+         3.941652568452089`15.649283326164166*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "9f039f17-861a-4f6c-93e2-7463d8729a37", "TestID" -> 
+         "CreationID" -> "479aa85f-04cd-43a0-a33f-12d0da301480", "TestID" -> 
          "LexicalPatternQ-BoundToken-Test4", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Validation.wlt", "EvaluationID" -> 
-         "8c173f04-73ce-44cf-a6a3-cb4e3533aca3", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Validation.wlt", "EvaluationID" -> 
+         "497edc22-7f11-437f-af21-ed12c5f14069", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalPatternQ[
             StringExpression["number", 
              FaizonZaman`LexicalCases`BoundToken[DigitCharacter]]]], 
          "ExpectedOutput" -> HoldForm[True], "ExpectedMessages" -> 
          HoldForm[{}], "ActualOutput" -> HoldForm[True], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000123`2.2404201092713873, "CPUTimeUsed" -> 
-         0.00012199999999928934`, "MemoryUsed" -> 3464, 
+         0.000126`2.2508855429495567, "CPUTimeUsed" -> 
+         0.00012599999999984846`, "MemoryUsed" -> 3464, 
          "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 9047841211770311072 -> 
+         None|>], 4114576011105012319 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055255016`15.648685237253364*^9, "SameTest" -> SameQ, 
-         "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
+         3.9416525684522150000000000001`15.649283326164184*^9, "SameTest" -> 
+         SameQ, "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "4d347510-857e-4ea1-98fd-a04e846b79a6", "TestID" -> 
+         "CreationID" -> "a047df85-96f3-4fdd-90a7-09e49056abc3", "TestID" -> 
          "LexicalPatternQ-BoundToken-Test5", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Validation.wlt", "EvaluationID" -> 
-         "9a05c9aa-a7db-43ee-9581-ccd17c3da66f", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Validation.wlt", "EvaluationID" -> 
+         "76871896-8b7d-4373-8d9d-877e10671491", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalPatternQ[
             FaizonZaman`LexicalCases`BoundToken["outer", "inner"]]], 
          "ExpectedOutput" -> HoldForm[True], "ExpectedMessages" -> 
          HoldForm[{}], "ActualOutput" -> HoldForm[True], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000163`2.3627026022359514, "CPUTimeUsed" -> 
-         0.00016300000000057935`, "MemoryUsed" -> 3400, 
+         0.000168`2.3758242795578566, "CPUTimeUsed" -> 
+         0.00016899999999964166`, "MemoryUsed" -> 3400, 
          "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 4254642573120381681 -> 
+         None|>], 8078855922026468847 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055255141`15.648685237253376*^9, "SameTest" -> SameQ, 
-         "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
+         3.9416525684523400000000000001`15.649283326164197*^9, "SameTest" -> 
+         SameQ, "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "4b4b4ecd-4e9a-4b0f-b625-d51cdca43033", "TestID" -> 
+         "CreationID" -> "c2a770f3-bc80-49f6-9458-09e6194e3270", "TestID" -> 
          "LexicalPatternQ-BoundToken-Test6", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Validation.wlt", "EvaluationID" -> 
-         "918ead84-c517-4fde-abef-698007653425", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Validation.wlt", "EvaluationID" -> 
+         "4bb14afe-6f21-4c88-8a62-bcd4ea01af32", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalPatternQ[
             FaizonZaman`LexicalCases`BoundToken[
              FaizonZaman`LexicalCases`BoundToken["outer"], "inner"]]], 
          "ExpectedOutput" -> HoldForm[True], "ExpectedMessages" -> 
          HoldForm[{}], "ActualOutput" -> HoldForm[True], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.00028`2.5976730291742105, "CPUTimeUsed" -> 0.000280000000000058, 
+         0.00027`2.5818787619909815, "CPUTimeUsed" -> 0.0002689999999994086, 
          "MemoryUsed" -> 3464, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 5067737525704771757 -> 
+         "Success", "FailureType" -> None|>], 4946066894588043695 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055255264`15.648685237253392*^9, "SameTest" -> SameQ, 
+         3.941652568452464`15.649283326164209*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "39efba31-6b83-4593-b997-a957fbbce2c4", "TestID" -> 
+         "CreationID" -> "ee02a6d0-5deb-473f-ac39-8d0bd2f3d6e6", "TestID" -> 
          "BoundToken-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Validation.wlt", "EvaluationID" -> 
-         "63f38162-7dd8-4f4c-b9cf-e3f210624848", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Validation.wlt", "EvaluationID" -> 
+         "2ce4bd31-d82b-4428-ae16-548a4b93a388", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`BoundToken["machine"]], "ExpectedOutput" -> 
          HoldForm[
            FaizonZaman`LexicalCases`BoundToken["machine"]], 
          "ExpectedMessages" -> HoldForm[{}], "ActualOutput" -> HoldForm[
            FaizonZaman`LexicalCases`BoundToken["machine"]], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.00002`1.4515449934959728, "CPUTimeUsed" -> 
-         0.000020999999998494445`, "MemoryUsed" -> 3400, 
-         "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 6493675226435398966 -> 
+         0.000021`1.4727342925659124, "CPUTimeUsed" -> 0.00002200000000129876,
+          "MemoryUsed" -> 3400, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 8981516007338415547 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055255387`15.648685237253407*^9, "SameTest" -> SameQ, 
+         3.941652568452588`15.649283326164221*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "529dcf70-46d8-476c-84a2-41a271620f4d", "TestID" -> 
+         "CreationID" -> "df75c1b0-6b3c-4e00-9445-cb2ae8892700", "TestID" -> 
          "BoundToken-Test2", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Validation.wlt", "EvaluationID" -> 
-         "fd12ee2f-ef47-45ac-9ac8-8585f7f00490", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Validation.wlt", "EvaluationID" -> 
+         "06945cae-5e08-42ed-bd46-884eeefb61d5", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`BoundToken[
             Alternatives["machine", "machines"]]], "ExpectedOutput" -> 
          HoldForm[
@@ -3888,20 +3890,20 @@ Tests/Validation.wlt", "EvaluationID" ->
          HoldForm[{}], "ActualOutput" -> HoldForm[
            FaizonZaman`LexicalCases`BoundToken[
             Alternatives["machine", "machines"]]], "ActualMessages" -> {}, 
-         "AbsoluteTimeUsed" -> 0.000019`1.4292685987848202, "CPUTimeUsed" -> 
-         0.000019999999999242846`, "MemoryUsed" -> 3408, 
+         "AbsoluteTimeUsed" -> 0.000021`1.4727342925659135, "CPUTimeUsed" -> 
+         0.000021000000000270802`, "MemoryUsed" -> 3408, 
          "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 6043894972136566263 -> 
+         None|>], 7953192617158452742 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.93622805525551`15.648685237253419*^9, "SameTest" -> SameQ, 
+         3.941652568452714`15.649283326164234*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "7ae1b682-6f84-473c-ba6b-1cd64a07f4de", "TestID" -> 
+         "CreationID" -> "e624f295-4e1d-40fc-a88d-6513afecd308", "TestID" -> 
          "BoundToken-Test3", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Validation.wlt", "EvaluationID" -> 
-         "ab2734c2-a94e-4991-9c25-c241d23e001f", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Validation.wlt", "EvaluationID" -> 
+         "18f0a6c4-7e62-43ee-bd11-6c53d791b9c1", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`BoundToken[
             Alternatives["A", 
              FaizonZaman`LexicalCases`WordToken[1]]]], "ExpectedOutput" -> 
@@ -3913,94 +3915,94 @@ Tests/Validation.wlt", "EvaluationID" ->
            FaizonZaman`LexicalCases`BoundToken[
             Alternatives["A", 
              FaizonZaman`LexicalCases`WordToken[1]]]], "ActualMessages" -> {},
-          "AbsoluteTimeUsed" -> 0.00002`1.4515449934959728, "CPUTimeUsed" -> 
-         0.000019999999999242846`, "MemoryUsed" -> 3416, 
+          "AbsoluteTimeUsed" -> 0.000021`1.4727342925659124, "CPUTimeUsed" -> 
+         0.000021000000000270802`, "MemoryUsed" -> 3416, 
          "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 6408261824071201997 -> 
+         None|>], 3178684048820881750 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055255632`15.648685237253432*^9, "SameTest" -> SameQ, 
+         3.941652568452839`15.649283326164252*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "aa381a18-3153-4119-aeb6-824e7e1a98ad", "TestID" -> 
+         "CreationID" -> "0370c5c2-9ba8-4b31-9b90-b1aea0973da3", "TestID" -> 
          "BoundToken-Test4", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Validation.wlt", "EvaluationID" -> 
-         "33778413-bd69-4f85-a26f-b8dd84b81e45", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Validation.wlt", "EvaluationID" -> 
+         "1de2ded4-40dc-45b1-a03c-af712c982904", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`BoundToken["outer", "inner"]], 
          "ExpectedOutput" -> HoldForm[
            FaizonZaman`LexicalCases`BoundToken["outer", "inner"]], 
          "ExpectedMessages" -> HoldForm[{}], "ActualOutput" -> HoldForm[
            FaizonZaman`LexicalCases`BoundToken["outer", "inner"]], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000019`1.4292685987848202, "CPUTimeUsed" -> 0.00001799999999896329,
+         0.00002`1.451544993495975, "CPUTimeUsed" -> 0.000020000000001019203`,
           "MemoryUsed" -> 3400, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 2743074917274203503 -> 
+         "Success", "FailureType" -> None|>], 4051779532048455603 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055255786`15.64868523725345*^9, "SameTest" -> SameQ, 
+         3.941652568452992`15.64928332616427*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "812e40da-4fdb-4ec3-8b69-a89cc404040b", "TestID" -> 
+         "CreationID" -> "c3cb775b-ae4f-4850-843e-10882c703aa0", "TestID" -> 
          "LexicalPatternQ-WordToken-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Validation.wlt", "EvaluationID" -> 
-         "92846b85-f16f-495e-85e8-1267498117ff", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Validation.wlt", "EvaluationID" -> 
+         "78931cfc-0429-463f-a20b-b25679ed1caf", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalPatternQ[
             StringExpression["pattern", 
              FaizonZaman`LexicalCases`WordToken[1]]]], "ExpectedOutput" -> 
          HoldForm[True], "ExpectedMessages" -> HoldForm[{}], "ActualOutput" -> 
          HoldForm[True], "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000079`2.0481420891224316, "CPUTimeUsed" -> 0.0000790000000012725, 
+         0.000083`2.069593090208068, "CPUTimeUsed" -> 0.00008300000000005525, 
          "MemoryUsed" -> 3400, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 2672530328825529400 -> 
+         "Success", "FailureType" -> None|>], 7533213457815559895 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.93622805525591`15.648685237253462*^9, "SameTest" -> SameQ, 
+         3.941652568453117`15.649283326164282*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "4a56c9e6-8263-4e7c-be38-39975ade84ec", "TestID" -> 
+         "CreationID" -> "eaa557de-fc03-4be5-9758-60f2422741b5", "TestID" -> 
          "LexicalPatternQ-WordToken-Test2", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Validation.wlt", "EvaluationID" -> 
-         "b50f77ba-2c84-4df1-b676-d6793b783508", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Validation.wlt", "EvaluationID" -> 
+         "04fa2190-24b7-4bac-a337-e0f85ce3fb86", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalPatternQ[
             StringExpression["number", 
              FaizonZaman`LexicalCases`WordToken[1, 2]]]], "ExpectedOutput" -> 
          HoldForm[True], "ExpectedMessages" -> HoldForm[{}], "ActualOutput" -> 
          HoldForm[True], "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000076`2.031328590112785, "CPUTimeUsed" -> 0.00007599999999818863, 
+         0.00008`2.0536049848239375, "CPUTimeUsed" -> 0.0000800000000005241, 
          "MemoryUsed" -> 3464, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 4251481798462211475 -> 
+         "Success", "FailureType" -> None|>], 1503811630220519023 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055256033`15.648685237253474*^9, "SameTest" -> SameQ, 
-         "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
+         3.9416525684532410000000000001`15.649283326164294*^9, "SameTest" -> 
+         SameQ, "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "e255b49d-dd81-49b1-b3b8-38d9c0c0b7ab", "TestID" -> 
+         "CreationID" -> "f3ca561e-af34-4892-a0cc-6476b8dc47de", "TestID" -> 
          "LexicalPatternQ-WordToken-Test3", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Validation.wlt", "EvaluationID" -> 
-         "db832ee0-bfbc-46ec-b15e-2f44d8f304f3", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Validation.wlt", "EvaluationID" -> 
+         "7e7612ef-25a8-4c8a-acc9-d7ad27d708a8", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalPatternQ[
             StringExpression["this", "is", 
              FaizonZaman`LexicalCases`WordToken[1, "KeepContractions"], 
              "place"]]], "ExpectedOutput" -> HoldForm[True], 
          "ExpectedMessages" -> HoldForm[{}], "ActualOutput" -> HoldForm[True],
           "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000077`2.0370057230044756, "CPUTimeUsed" -> 0.00007700000000099294,
-          "MemoryUsed" -> 3400, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 8014880731880249926 -> 
+         0.000083`2.0695930902080675, "CPUTimeUsed" -> 0.00008400000000108321,
+          "MemoryUsed" -> 3520, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 7649746762692750214 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055256188`15.648685237253492*^9, "SameTest" -> SameQ, 
+         3.941652568453394`15.649283326164312*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "4ea63d02-2b71-4925-b650-ea47424f574f", "TestID" -> 
+         "CreationID" -> "7c0922ce-4fa0-40ea-bd93-c49a1088e7d6", "TestID" -> 
          "LexicalPatternQ-OptionalToken-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Validation.wlt", "EvaluationID" -> 
-         "03d0baaf-a265-49c4-a562-99f58627964d", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Validation.wlt", "EvaluationID" -> 
+         "5614eb12-3af0-4f2a-82ac-2abbdd9ebb4e", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalPatternQ[
             StringExpression["this is a", 
              FaizonZaman`LexicalCases`OptionalToken[
@@ -4008,39 +4010,38 @@ Tests/Validation.wlt", "EvaluationID" ->
          "ExpectedOutput" -> HoldForm[True], "ExpectedMessages" -> 
          HoldForm[{}], "ActualOutput" -> HoldForm[True], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000123`2.2404201092713873, "CPUTimeUsed" -> 0.0001230000000003173, 
-         "MemoryUsed" -> 3464, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 2507349986999150869 -> 
+         0.000141`2.299734110487374, "CPUTimeUsed" -> 0.00014100000000105695`,
+          "MemoryUsed" -> 3584, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 3770453374826065973 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055256309`15.64868523725351*^9, "SameTest" -> SameQ, 
+         3.941652568453516`15.649283326164324*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "f1a871ba-71c7-4918-9f56-777d8cdd6447", "TestID" -> 
+         "CreationID" -> "fff05373-04e7-4cf1-aa5e-71b0a202e2dc", "TestID" -> 
          "LexicalPatternQ-OptionalToken-Test2", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Validation.wlt", "EvaluationID" -> 
-         "06bb5d8c-aa20-49c7-8eb5-14d3a46fd2da", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Validation.wlt", "EvaluationID" -> 
+         "aafda4a7-4a52-4f77-b12d-70670018275c", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalPatternQ[
             StringExpression["cool", 
              FaizonZaman`LexicalCases`OptionalToken["crazy"], "computer"]]], 
          "ExpectedOutput" -> HoldForm[True], "ExpectedMessages" -> 
          HoldForm[{}], "ActualOutput" -> HoldForm[True], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000119`2.2260619592245243, "CPUTimeUsed" -> 
-         0.00012099999999826139`, "MemoryUsed" -> 3464, 
-         "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 6025478653320553316 -> 
+         0.000131`2.267786293487758, "CPUTimeUsed" -> 0.00013199999999891077`,
+          "MemoryUsed" -> 3464, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 877110483297367862 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055256432`15.648685237253522*^9, "SameTest" -> SameQ, 
+         3.941652568453644`15.649283326164337*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "1777708b-ce3d-47e8-9866-5492986a0eea", "TestID" -> 
+         "CreationID" -> "26bde218-7dda-473a-8a26-97d5ea768788", "TestID" -> 
          "LexicalPatternQ-OptionalToken-Test3", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Validation.wlt", "EvaluationID" -> 
-         "bfee9e7c-574d-4d1a-860b-6fb26d40afe1", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Validation.wlt", "EvaluationID" -> 
+         "0e0f56dd-9638-4f59-88c4-5b7b48c0348f", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalPatternQ[
             StringExpression["this", 
              FaizonZaman`LexicalCases`OptionalToken[
@@ -4050,95 +4051,98 @@ Tests/Validation.wlt", "EvaluationID" ->
          "ExpectedOutput" -> HoldForm[True], "ExpectedMessages" -> 
          HoldForm[{}], "ActualOutput" -> HoldForm[True], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000122`2.236874828506738, "CPUTimeUsed" -> 0.0001260000000016248, 
-         "MemoryUsed" -> 3400, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 2542610179066668380 -> 
+         0.000136`2.284053906202211, "CPUTimeUsed" -> 0.00013599999999946988`,
+          "MemoryUsed" -> 3480, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 9193668707820935708 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055256581`15.648685237253538*^9, "SameTest" -> SameQ, 
+         3.941652568453798`15.649283326164355*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "e9823e7f-308a-4842-83d2-b194b93c12b4", "TestID" -> 
+         "CreationID" -> "623a4163-d408-4067-9778-5195edfb58fa", "TestID" -> 
          "LexicalPatternQ-BoundToken-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Validation.wlt", "EvaluationID" -> 
-         "c7ce8cc6-71b5-4b61-9b4b-800c1e09c76e", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Validation.wlt", "EvaluationID" -> 
+         "ac07df99-557a-4c62-a924-8912dd170b3f", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalPatternQ[
             FaizonZaman`LexicalCases`BoundToken[
              FaizonZaman`LexicalCases`WordToken[1], 
              FaizonZaman`LexicalCases`BoundToken["car"]]]], "ExpectedOutput" -> 
          HoldForm[True], "ExpectedMessages" -> HoldForm[{}], "ActualOutput" -> 
          HoldForm[True], "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000266`2.5753966344630586, "CPUTimeUsed" -> 0.0002670000000009054, 
-         "MemoryUsed" -> 3464, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 93871868002199371 -> 
+         0.0003`2.6276362525516563, "CPUTimeUsed" -> 0.0003010000000003288, 
+         "MemoryUsed" -> 3584, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 113884564295358422 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055256733`15.648685237253556*^9, "SameTest" -> SameQ, 
+         3.941652568453954`15.649283326164372*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "2596adee-fa65-4145-ba8f-4855bfa93098", "TestID" -> 
+         "CreationID" -> "ecb5014d-6a04-4f29-8e2d-8e014cd5a077", "TestID" -> 
          "LexicalPatternQ-TypeToken-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Validation.wlt", "EvaluationID" -> 
-         "20cea5e3-39f1-4e3d-80ed-23461545a7f4", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Validation.wlt", "EvaluationID" -> 
+         "ac69db3d-e6dd-4198-95bf-fd044a88e457", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalPatternQ[StringExpression[
               Pattern[$CellContext`adjective, 
                FaizonZaman`LexicalCases`TypeToken["Adjective"]], 
               "sentence"] :> $CellContext`adjective]], "ExpectedOutput" -> 
          HoldForm[True], "ExpectedMessages" -> HoldForm[{}], "ActualOutput" -> 
          HoldForm[True], "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000098`2.1417410735244866, "CPUTimeUsed" -> 0.00009800000000126374,
-          "MemoryUsed" -> 3480, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 7637786766936790378 -> 
+         0.000181`2.4081935727011787, "CPUTimeUsed" -> 
+         0.00018199999999879424`, "MemoryUsed" -> 3456, 
+         "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
+         None|>], 1938317537617362843 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055256883`15.648685237253568*^9, "SameTest" -> SameQ, 
-         "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
+         3.9416525684541110000000000001`15.649283326164388*^9, "SameTest" -> 
+         SameQ, "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "12976164-a91e-4475-9498-e968540ecd3d", "TestID" -> 
+         "CreationID" -> "acc64a0e-5e67-401d-a20a-8b445a1873d7", "TestID" -> 
          "LexicalPatternQ-SynonymToken-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Validation.wlt", "EvaluationID" -> 
-         "12799a1b-05f6-4e12-84cd-b3a14568c4e2", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Validation.wlt", "EvaluationID" -> 
+         "598fa083-c3af-4b53-81d9-84150894e4c2", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalPatternQ[
             StringExpression[
              FaizonZaman`LexicalCases`SynonymToken["cool"], " sentence"]]], 
          "ExpectedOutput" -> HoldForm[True], "ExpectedMessages" -> 
          HoldForm[{}], "ActualOutput" -> HoldForm[True], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000083`2.0695930902080653, "CPUTimeUsed" -> 0.00008300000000005525,
-          "MemoryUsed" -> 3456, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 1238948855221235699 -> 
+         0.000112`2.1997330205021752, "CPUTimeUsed" -> 
+         0.00011199999999966792`, "MemoryUsed" -> 3456, 
+         "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
+         None|>], 7253812645591842241 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.93622805526973`15.64868523725499*^9, "SameTest" -> SameQ, 
+         3.94165256846562`15.649283326165659*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "72dfc0ce-3eeb-450d-8adb-c182e8aef0ba", "TestID" -> 
+         "CreationID" -> "c99f2625-fa17-4923-8d3a-4ddf95ebfdf2", "TestID" -> 
          "BoundToken-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Patterns.wlt", "EvaluationID" -> "9b918b59-a2b0-4d42-beee-5d172162c4bb",
-          "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Patterns.wlt", "EvaluationID" -> 
+         "b516c2cd-4a62-4cc1-9e41-50d49ee1a8e9", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`BoundToken["machine"]], "ExpectedOutput" -> 
          HoldForm[
            FaizonZaman`LexicalCases`BoundToken["machine"]], 
          "ExpectedMessages" -> HoldForm[{}], "ActualOutput" -> HoldForm[
            FaizonZaman`LexicalCases`BoundToken["machine"]], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.00002`1.4515449934959728, "CPUTimeUsed" -> 0.00001799999999896329, 
-         "MemoryUsed" -> 3400, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 3578227485993311189 -> 
+         0.000024`1.5307262395435999, "CPUTimeUsed" -> 
+         0.000023999999999801958`, "MemoryUsed" -> 3400, 
+         "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
+         None|>], 6986154076067112683 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.93622805526991`15.648685237255005*^9, "SameTest" -> SameQ, 
-         "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
+         3.9416525684657930000000000001`15.649283326165676*^9, "SameTest" -> 
+         SameQ, "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "4b1f965c-0368-4dc8-8130-ca6567d5470c", "TestID" -> 
+         "CreationID" -> "603b6b7d-6f2a-4ef4-bad2-d13aa3c50ba7", "TestID" -> 
          "BoundToken-Test2", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Patterns.wlt", "EvaluationID" -> "f4b09661-cfee-4293-ac5a-881fbadc6ea5",
-          "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Patterns.wlt", "EvaluationID" -> 
+         "67cb5e1d-3814-437a-8efa-1c0c54337122", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`BoundToken[
             Alternatives["machine", "machines"]]], "ExpectedOutput" -> 
          HoldForm[
@@ -4147,58 +4151,58 @@ Tests/Patterns.wlt", "EvaluationID" -> "f4b09661-cfee-4293-ac5a-881fbadc6ea5",
          HoldForm[{}], "ActualOutput" -> HoldForm[
            FaizonZaman`LexicalCases`BoundToken[
             Alternatives["machine", "machines"]]], "ActualMessages" -> {}, 
-         "AbsoluteTimeUsed" -> 0.000019`1.429268598784821, "CPUTimeUsed" -> 
-         0.000019000000001767603`, "MemoryUsed" -> 3408, 
+         "AbsoluteTimeUsed" -> 0.000023`1.512242833849586, "CPUTimeUsed" -> 
+         0.000023000000000550358`, "MemoryUsed" -> 3408, 
          "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 7536762299147373297 -> 
+         None|>], 6266150768099164970 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055270079`15.648685237255027*^9, "SameTest" -> SameQ, 
-         "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
+         3.9416525684659600000000000001`15.649283326165698*^9, "SameTest" -> 
+         SameQ, "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "04adb75a-04ad-4350-8a76-fda4c3ab1df7", "TestID" -> 
+         "CreationID" -> "a4a5e792-10f5-4ece-a01b-29468a3021c7", "TestID" -> 
          "WordToken-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Patterns.wlt", "EvaluationID" -> "36633703-1ebb-4fee-a062-e15c7bd3cb7d",
-          "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Patterns.wlt", "EvaluationID" -> 
+         "85ae5da8-69b8-4100-aad8-3857ef634cad", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`WordToken[3]], "ExpectedOutput" -> 
          HoldForm[
            FaizonZaman`LexicalCases`WordToken[3]], "ExpectedMessages" -> 
          HoldForm[{}], "ActualOutput" -> HoldForm[
            FaizonZaman`LexicalCases`WordToken[3]], "ActualMessages" -> {}, 
-         "AbsoluteTimeUsed" -> 0.000028`1.5976730291742125, "CPUTimeUsed" -> 
-         0.000027999999998584713`, "MemoryUsed" -> 3400, 
+         "AbsoluteTimeUsed" -> 0.000021`1.4727342925659135, "CPUTimeUsed" -> 
+         0.000021000000000270802`, "MemoryUsed" -> 3400, 
          "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 6101776332887512581 -> 
+         None|>], 515440805860387417 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055270211`15.648685237255041*^9, "SameTest" -> SameQ, 
+         3.941652568466091`15.64928332616571*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "3fefaea9-cd19-4c87-9fb4-3263031e0f0f", "TestID" -> 
+         "CreationID" -> "56aba196-e193-480e-98e5-367142b84b0f", "TestID" -> 
          "WordToken-Test2", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Patterns.wlt", "EvaluationID" -> "1a3923b4-6817-409b-88cc-f7b509ee9511",
-          "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Patterns.wlt", "EvaluationID" -> 
+         "ea79e9f7-f313-4065-a699-eba21264ed2f", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`WordToken[1, 4]], "ExpectedOutput" -> 
          HoldForm[
            FaizonZaman`LexicalCases`WordToken[1, 4]], "ExpectedMessages" -> 
          HoldForm[{}], "ActualOutput" -> HoldForm[
            FaizonZaman`LexicalCases`WordToken[1, 4]], "ActualMessages" -> {}, 
-         "AbsoluteTimeUsed" -> 0.000019`1.429268598784821, "CPUTimeUsed" -> 
-         0.00001799999999896329, "MemoryUsed" -> 3400, 
+         "AbsoluteTimeUsed" -> 0.000022`1.492937678654201, "CPUTimeUsed" -> 
+         0.0000219999999995224, "MemoryUsed" -> 3400, 
          "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 1149338181538954114 -> 
+         None|>], 4329624689027405222 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055270378`15.648685237255057*^9, "SameTest" -> SameQ, 
-         "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
+         3.9416525684662500000000000001`15.649283326165728*^9, "SameTest" -> 
+         SameQ, "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "62e27c85-3f5b-4df5-b9b3-8c755d5e3dbc", "TestID" -> 
+         "CreationID" -> "9895dc28-94f7-4041-a18b-86a28a0d965a", "TestID" -> 
          "OptionalToken-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Patterns.wlt", "EvaluationID" -> "5a2942db-4a06-4e50-9b18-259b43f9c89d",
-          "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Patterns.wlt", "EvaluationID" -> 
+         "4611ec71-0a8c-4057-95be-ede366374615", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`OptionalToken[
             FaizonZaman`LexicalCases`TypeToken["Adjective"]]], 
          "ExpectedOutput" -> HoldForm[
@@ -4208,20 +4212,20 @@ Tests/Patterns.wlt", "EvaluationID" -> "5a2942db-4a06-4e50-9b18-259b43f9c89d",
            FaizonZaman`LexicalCases`OptionalToken[
             FaizonZaman`LexicalCases`TypeToken["Adjective"]]], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000018`1.4057875029352978, "CPUTimeUsed" -> 
-         0.000018999999999991246`, "MemoryUsed" -> 3408, 
+         0.000021`1.4727342925659124, "CPUTimeUsed" -> 
+         0.000020999999998494445`, "MemoryUsed" -> 3408, 
          "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 2625145842747265185 -> 
+         None|>], 4454767882120496001 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.93622805527051`15.648685237255075*^9, "SameTest" -> SameQ, 
+         3.94165256846638`15.64928332616574*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "be04889f-0b33-4051-8a36-2cca099cd07b", "TestID" -> 
+         "CreationID" -> "0fa6a8da-6afa-4330-a4a9-19edd35cf682", "TestID" -> 
          "OptionalToken-Test2", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Patterns.wlt", "EvaluationID" -> "e04bebae-6f44-4a6b-b331-e662dd92df47",
-          "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Patterns.wlt", "EvaluationID" -> 
+         "6ded00ce-ffaf-408a-b2b8-549b402a41d8", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`OptionalToken[
             StringExpression[
              Pattern[$CellContext`adjective, 
@@ -4237,40 +4241,39 @@ Tests/Patterns.wlt", "EvaluationID" -> "e04bebae-6f44-4a6b-b331-e662dd92df47",
              Pattern[$CellContext`adjective, 
               FaizonZaman`LexicalCases`TypeToken["Adjective"]], "sentence"]]],
           "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000019`1.4292685987848222, "CPUTimeUsed" -> 
-         0.000019000000001767603`, "MemoryUsed" -> 3432, 
+         0.000021`1.4727342925659135, "CPUTimeUsed" -> 
+         0.000020999999998494445`, "MemoryUsed" -> 3432, 
          "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 416061366580287145 -> 
+         None|>], 3551985802961337668 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055270662`15.648685237255092*^9, "SameTest" -> SameQ, 
+         3.941652568466532`15.649283326165758*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "b613bb40-b165-47f3-9db7-db4ca4f9bd45", "TestID" -> 
+         "CreationID" -> "ca044905-d0a9-4302-93bf-e7ddf5a35d38", "TestID" -> 
          "TypeToken-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Patterns.wlt", "EvaluationID" -> "74859518-64d2-462e-b39f-30da4c65dc9f",
-          "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Patterns.wlt", "EvaluationID" -> 
+         "4ceb79b7-431b-4bae-a252-7bd6d4589a7b", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`TypeToken["Adjective"]], "ExpectedOutput" -> 
          HoldForm[
            FaizonZaman`LexicalCases`TypeToken["Adjective"]], 
          "ExpectedMessages" -> HoldForm[{}], "ActualOutput" -> HoldForm[
            FaizonZaman`LexicalCases`TypeToken["Adjective"]], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000018`1.4057875029352978, "CPUTimeUsed" -> 
-         0.000017000000001488047`, "MemoryUsed" -> 3400, 
-         "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 694606893188369687 -> 
+         0.00002`1.451544993495975, "CPUTimeUsed" -> 0.000018999999999991246`,
+          "MemoryUsed" -> 3400, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 8866369715668707575 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055270789`15.648685237255105*^9, "SameTest" -> SameQ, 
+         3.941652568466655`15.64928332616577*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "6bb14e63-0794-444f-9f80-c00f4ebfbd01", "TestID" -> 
+         "CreationID" -> "db82ffcf-bb6a-4b55-bde2-e2ac7721c2ec", "TestID" -> 
          "TypeToken-Test2", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Patterns.wlt", "EvaluationID" -> "720e8334-86d6-4ff8-8d50-6c623ae69018",
-          "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Patterns.wlt", "EvaluationID" -> 
+         "0b17a42e-8755-4bcd-9d63-4b9227b15c56", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`TypeToken[
             Alternatives["Adjective", "Noun"]]], "ExpectedOutput" -> 
          HoldForm[
@@ -4279,40 +4282,40 @@ Tests/Patterns.wlt", "EvaluationID" -> "720e8334-86d6-4ff8-8d50-6c623ae69018",
          HoldForm[{}], "ActualOutput" -> HoldForm[
            FaizonZaman`LexicalCases`TypeToken[
             Alternatives["Adjective", "Noun"]]], "ActualMessages" -> {}, 
-         "AbsoluteTimeUsed" -> 0.000018`1.4057875029352978, "CPUTimeUsed" -> 
+         "AbsoluteTimeUsed" -> 0.000019`1.4292685987848222, "CPUTimeUsed" -> 
          0.000018999999999991246`, "MemoryUsed" -> 3408, 
          "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 6557883464713480487 -> 
+         None|>], 225594909919173518 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055270939`15.64868523725512*^9, "SameTest" -> SameQ, 
+         3.941652568466805`15.649283326165788*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "839e0e33-4cf7-4561-a3f6-4c24cf5cf15e", "TestID" -> 
+         "CreationID" -> "e00852f8-f9d3-46e7-998e-27e8e64b904a", "TestID" -> 
          "SynonymToken-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Patterns.wlt", "EvaluationID" -> "b89ea21e-deab-4985-a776-e51bba7929c0",
-          "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Patterns.wlt", "EvaluationID" -> 
+         "5aba0aa4-343c-4c65-91ed-6ecaf18823fd", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`SynonymToken["good"]], "ExpectedOutput" -> 
          HoldForm[
            FaizonZaman`LexicalCases`SynonymToken["good"]], "ExpectedMessages" -> 
          HoldForm[{}], "ActualOutput" -> HoldForm[
            FaizonZaman`LexicalCases`SynonymToken["good"]], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000018`1.4057875029352978, "CPUTimeUsed" -> 
-         0.000019000000001767603`, "MemoryUsed" -> 3400, 
+         0.000019`1.4292685987848222, "CPUTimeUsed" -> 
+         0.000018999999999991246`, "MemoryUsed" -> 3400, 
          "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 6699676424675890379 -> 
+         None|>], 274424456231345531 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055271063`15.648685237255135*^9, "SameTest" -> SameQ, 
+         3.941652568466925`15.6492833261658*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "2b65295d-e6a8-4b47-80a7-64e8fc897f1d", "TestID" -> 
+         "CreationID" -> "513a0ad9-9170-4532-a352-4d2f7892020e", "TestID" -> 
          "SynonymToken-Test2", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Patterns.wlt", "EvaluationID" -> "cc7e8d48-c33b-4e4b-b9c3-f6848e5c87bb",
-          "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Patterns.wlt", "EvaluationID" -> 
+         "c5119023-414d-4eb2-a585-6a51dfdff892", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`SynonymToken[
             Alternatives["good", "bad"]]], "ExpectedOutput" -> HoldForm[
            FaizonZaman`LexicalCases`SynonymToken[
@@ -4320,20 +4323,20 @@ Tests/Patterns.wlt", "EvaluationID" -> "cc7e8d48-c33b-4e4b-b9c3-f6848e5c87bb",
           "ActualOutput" -> HoldForm[
            FaizonZaman`LexicalCases`SynonymToken[
             Alternatives["good", "bad"]]], "ActualMessages" -> {}, 
-         "AbsoluteTimeUsed" -> 0.000018`1.4057875029352978, "CPUTimeUsed" -> 
-         0.000018000000000739647`, "MemoryUsed" -> 3408, 
+         "AbsoluteTimeUsed" -> 0.00002`1.451544993495975, "CPUTimeUsed" -> 
+         0.000019999999999242846`, "MemoryUsed" -> 3408, 
          "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 2101546182814465257 -> 
+         None|>], 5910457642525920299 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055271222`15.648685237255151*^9, "SameTest" -> SameQ, 
+         3.941652568467087`15.649283326165822*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "9d335652-d1f8-4daa-a998-b581a9d6737c", "TestID" -> 
+         "CreationID" -> "3b87f888-0866-45e8-94a0-269fbc1ce727", "TestID" -> 
          "LexicalPattern-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Patterns.wlt", "EvaluationID" -> "71640d23-a2f5-4244-8d79-59ef5c1de83a",
-          "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Patterns.wlt", "EvaluationID" -> 
+         "5a1bffd9-a969-4a6c-ad61-c55b8f256f41", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`LexicalPattern[
             StringExpression["Alice ", 
              FaizonZaman`LexicalCases`TypeToken["Verb"], 
@@ -4349,20 +4352,20 @@ Tests/Patterns.wlt", "EvaluationID" -> "71640d23-a2f5-4244-8d79-59ef5c1de83a",
              FaizonZaman`LexicalCases`TypeToken["Verb"], 
              FaizonZaman`LexicalCases`TypeToken["Adverb"]]]], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000027`1.5818787619909769, "CPUTimeUsed" -> 
+         0.000026`1.5654883458028115, "CPUTimeUsed" -> 
          0.000026999999999333113`, "MemoryUsed" -> 3416, 
          "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 2429008949994950419 -> 
+         None|>], 2666139660203696194 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055271378`15.648685237255169*^9, "SameTest" -> SameQ, 
+         3.941652568467244`15.64928332616584*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "a33a3a16-4fd9-41b3-9d6a-458eefa7dac1", "TestID" -> 
+         "CreationID" -> "30354ebf-2a32-499c-afef-08cfeac3e279", "TestID" -> 
          "ExpandPattern-BoundToken-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Patterns.wlt", "EvaluationID" -> "3c8bffd3-941b-47ad-95b8-f97aa98ff5f6",
-          "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Patterns.wlt", "EvaluationID" -> 
+         "5d006004-8923-43c7-ad6f-baa11ad5cd6c", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`ExpandPattern["", 
             FaizonZaman`LexicalCases`BoundToken[
              FaizonZaman`LexicalCases`BoundToken["outer"], "inner"]]], 
@@ -4374,20 +4377,20 @@ Tests/Patterns.wlt", "EvaluationID" -> "3c8bffd3-941b-47ad-95b8-f97aa98ff5f6",
            StringExpression[
            WordBoundary, "outer", WordBoundary, "inner", WordBoundary, 
             "outer", WordBoundary]], "ActualMessages" -> {}, 
-         "AbsoluteTimeUsed" -> 0.002424`3.53504761332624, "CPUTimeUsed" -> 
-         0.0024269999999972924`, "MemoryUsed" -> 3848, 
+         "AbsoluteTimeUsed" -> 0.002585`3.5629755452619554, "CPUTimeUsed" -> 
+         0.0025890000000003965`, "MemoryUsed" -> 3784, 
          "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 561608287076945412 -> 
+         None|>], 5978718917455664422 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055271507`15.648685237255187*^9, "SameTest" -> SameQ, 
+         3.941652568467377`15.649283326165852*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "6b357ba1-a4df-4278-ae6b-7398eea047bf", "TestID" -> 
+         "CreationID" -> "f1522f9b-2fa7-4779-b52b-fb5146cdd7ee", "TestID" -> 
          "ExpandPattern-BoundToken-Test2", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Patterns.wlt", "EvaluationID" -> "dc71902a-eb70-4b2f-9445-e291e28ac673",
-          "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Patterns.wlt", "EvaluationID" -> 
+         "ec87f179-391b-40f5-aee8-f0bc85fe29c1", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`ExpandPattern["nice computer big", 
             FaizonZaman`LexicalCases`BoundToken[
              FaizonZaman`LexicalCases`TypeToken[
@@ -4405,19 +4408,19 @@ Tests/Patterns.wlt", "EvaluationID" -> "dc71902a-eb70-4b2f-9445-e291e28ac673",
             Alternatives[
              Alternatives["nice", "big"], "computer"]]], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.004965`3.84643425066339, "CPUTimeUsed" -> 0.004312999999999789, 
+         0.005221`3.8682686910427098, "CPUTimeUsed" -> 0.004559000000000424, 
          "MemoryUsed" -> 4216, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 6554996385984915490 -> 
+         "Success", "FailureType" -> None|>], 5202153321697176744 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055284428`15.64868523725661*^9, "SameTest" -> SameQ, 
+         3.941652568480612`15.64928332616731*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "a4e558f7-9d30-4298-95dc-0494cbc0e34a", "TestID" -> 
+         "CreationID" -> "6e5dad50-02ed-4c1b-8a6e-49aaa462f922", "TestID" -> 
          "Utilities-ExtractHeads-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Utilities.wlt", "EvaluationID" -> 
-         "0d6c7551-5fc1-4807-9ce5-4f6a2c5e0f46", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Utilities.wlt", "EvaluationID" -> 
+         "49c9835f-e024-4c35-b18c-dca17f5734e9", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`Utilities`ExtractHeads[
             StringExpression[
              FaizonZaman`LexicalCases`TypeToken["Adverb"], 
@@ -4434,20 +4437,20 @@ Tests/Utilities.wlt", "EvaluationID" ->
             FaizonZaman`LexicalCases`TypeToken, Alternatives, 
             FaizonZaman`LexicalCases`BoundToken, StringExpression}], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000033`1.6690289377098768, "CPUTimeUsed" -> 
-         0.000031999999999143824`, "MemoryUsed" -> 3504, 
+         0.000033`1.669028937709881, "CPUTimeUsed" -> 
+         0.000032999999998395424`, "MemoryUsed" -> 3504, 
          "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 1325278673371308066 -> 
+         None|>], 2107517012260374201 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055284607`15.648685237256627*^9, "SameTest" -> SameQ, 
-         "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
+         3.9416525684808000000000000001`15.649283326167332*^9, "SameTest" -> 
+         SameQ, "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "8bb2db89-1963-40fc-a9e9-a68a0e35af85", "TestID" -> 
+         "CreationID" -> "5029a2b1-b2c3-45d7-8cf5-68fb1772c5fc", "TestID" -> 
          "Utilities-ExtractHeads-Test2", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Utilities.wlt", "EvaluationID" -> 
-         "01cbb5a6-ff04-4872-a74d-f611d282bbbf", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Utilities.wlt", "EvaluationID" -> 
+         "66bcd130-51bd-4b08-9352-86cb820a12ee", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`Utilities`ExtractHeads[
             StringExpression[
              FaizonZaman`LexicalCases`TypeToken[
@@ -4463,17 +4466,17 @@ Tests/Utilities.wlt", "EvaluationID" ->
          0.000027`1.581878761990981, "CPUTimeUsed" -> 
          0.000026999999999333113`, "MemoryUsed" -> 3480, 
          "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 4260582015449639816 -> 
+         None|>], 8543622516842411926 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055284754`15.648685237256645*^9, "SameTest" -> SameQ, 
+         3.941652568480953`15.64928332616735*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "6441973c-baee-4e03-b561-0c52c5e5c5bb", "TestID" -> 
+         "CreationID" -> "ca8170bc-2e69-44b0-abf3-fb390dec1cff", "TestID" -> 
          "Utilities-ExtractHeads-Test3", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Utilities.wlt", "EvaluationID" -> 
-         "ca39af2e-481b-419e-ae5c-de5eae1264b2", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Utilities.wlt", "EvaluationID" -> 
+         "4b365c5d-e9c6-48e6-b4c7-3888d5dc6ee9", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`Utilities`ExtractHeads[
            FaizonZaman`LexicalCases`$SampleStringExpression]], 
          "ExpectedOutput" -> 
@@ -4481,20 +4484,19 @@ Tests/Utilities.wlt", "EvaluationID" ->
          "ExpectedMessages" -> HoldForm[{}], "ActualOutput" -> 
          HoldForm[{FaizonZaman`LexicalCases`TypeToken, StringExpression}], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000024`1.5307262395435983, "CPUTimeUsed" -> 
-         0.000024999999999053557`, "MemoryUsed" -> 3464, 
-         "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 5558638285442861371 -> 
+         0.000026`1.5654883458028126, "CPUTimeUsed" -> 0.00002600000000185787,
+          "MemoryUsed" -> 3464, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 3114714574091188636 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055284929`15.648685237256666*^9, "SameTest" -> SameQ, 
+         3.941652568481132`15.649283326167366*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "df244eda-6439-4833-862d-4d71a38c5258", "TestID" -> 
+         "CreationID" -> "699c784f-986b-4666-af9c-bb2dcd14fb5e", "TestID" -> 
          "Utilities-GetFileExtension-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Utilities.wlt", "EvaluationID" -> 
-         "bef8c40a-a589-4ff0-a129-252fee0718f7", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Utilities.wlt", "EvaluationID" -> 
+         "cc198e15-f7b8-4ca1-8aa2-caffa469cd80", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`Utilities`GetFileExtension[
             File[
              
@@ -4503,19 +4505,20 @@ Tests/Utilities.wlt", "EvaluationID" ->
                "AliceInWonderland.txt"}]]]], "ExpectedOutput" -> 
          HoldForm["txt"], "ExpectedMessages" -> HoldForm[{}], "ActualOutput" -> 
          HoldForm["txt"], "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000327`2.665062750492278, "CPUTimeUsed" -> 0.0003279999999996619, 
-         "MemoryUsed" -> 23816, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 4294541679137361893 -> 
+         0.000311`2.6432753868588317, "CPUTimeUsed" -> 
+         0.00031300000000022976`, "MemoryUsed" -> 23968, 
+         "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
+         None|>], 3278599112882408247 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055285121`15.648685237256688*^9, "SameTest" -> SameQ, 
+         3.941652568481337`15.649283326167392*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "1133aa4b-4fa6-4efc-847b-88c6a49bc43f", "TestID" -> 
+         "CreationID" -> "9d3736db-e2a4-49df-9eea-c640ba4984bd", "TestID" -> 
          "Utilities-MatchTrim-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Utilities.wlt", "EvaluationID" -> 
-         "179a4858-a915-4ea6-83d0-147d5a06139f", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Utilities.wlt", "EvaluationID" -> 
+         "d403b7b1-a012-4027-a69a-ce9d515ca7f1", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`Utilities`MatchTrim[
            True, {<|"Match" -> " past", "Position" -> {{49, 53}}|>, <|
              "Match" -> " few", "Position" -> {{54, 57}}|>, <|
@@ -4535,19 +4538,19 @@ Tests/Utilities.wlt", "EvaluationID" ->
              "Position" -> {{146, 150}, {181, 185}, {506, 510}}|>, <|
             "Match" -> "single", "Position" -> {{305, 310}}|>}], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000244`2.537904824170721, "CPUTimeUsed" -> 0.00024499999999960664`,
+         0.000257`2.560448121163289, "CPUTimeUsed" -> 0.00025599999999847967`,
           "MemoryUsed" -> 5784, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 6630750730752540599 -> 
+         "Success", "FailureType" -> None|>], 2031687623572510462 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055285312`15.648685237256709*^9, "SameTest" -> SameQ, 
+         3.94165256848154`15.649283326167414*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "94bc7343-df61-4d90-80a0-205192552a16", "TestID" -> 
+         "CreationID" -> "e41ba228-55ad-4f0f-90e3-7ce18c2b6c2a", "TestID" -> 
          "Utilities-OptionsJoin-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Utilities.wlt", "EvaluationID" -> 
-         "76ce55ca-d150-4c52-a177-bd9e93deaa52", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Utilities.wlt", "EvaluationID" -> 
+         "f07471ac-0786-4105-853e-f1a3085d0ae7", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`Utilities`OptionsJoin[
            FaizonZaman`LexicalCases`LexicalCases, 
             FaizonZaman`LexicalCases`LexicalDispersionPlot]], 
@@ -4570,39 +4573,39 @@ Tests/Utilities.wlt", "EvaluationID" ->
             Automatic, FaizonZaman`LexicalCases`HideMissing -> False, 
             FaizonZaman`LexicalCases`DataJoin -> False}], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.00006`1.9286662482156351, "CPUTimeUsed" -> 0.00006099999999875649, 
+         0.000036`1.706817498599281, "CPUTimeUsed" -> 0.00003700000000073089, 
          "MemoryUsed" -> 4144, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 219929901476506845 -> 
+         "Success", "FailureType" -> None|>], 8903207845384533819 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055285473`15.648685237256727*^9, "SameTest" -> SameQ, 
+         3.941652568481709`15.64928332616743*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "1de8080b-de30-4fff-9641-afbf9f418669", "TestID" -> 
+         "CreationID" -> "58bbc67d-4a27-4bb9-92d9-a6f0414fad03", "TestID" -> 
          "Utilities-ReplaceEmptyListWithMissing-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Utilities.wlt", "EvaluationID" -> 
-         "cf307edf-7182-4c67-ba42-323b82180192", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Utilities.wlt", "EvaluationID" -> 
+         "5581fbf3-7ab5-469b-ac13-055976affbfc", "Input" -> HoldForm[
            
            FaizonZaman`LexicalCases`Utilities`ReplaceEmptyListWithMissing[{{}}\
 ]], "ExpectedOutput" -> HoldForm[{
             Missing["NoMatches"]}], "ExpectedMessages" -> HoldForm[{}], 
          "ActualOutput" -> HoldForm[{
             Missing["NoMatches"]}], "ActualMessages" -> {}, 
-         "AbsoluteTimeUsed" -> 0.000027`1.5818787619909789, "CPUTimeUsed" -> 
-         0.000029000000001389026`, "MemoryUsed" -> 3448, 
+         "AbsoluteTimeUsed" -> 0.000022`1.4929376786542, "CPUTimeUsed" -> 
+         0.000022999999998774, "MemoryUsed" -> 3448, 
          "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 6114073732739887552 -> 
+         None|>], 8989337047826912535 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055285633`15.648685237256743*^9, "SameTest" -> SameQ, 
+         3.941652568481878`15.649283326167447*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "18b9df9f-ad25-4885-918e-20a6e5e5e451", "TestID" -> 
+         "CreationID" -> "b5c4e7fa-15b3-4def-b039-f9b936e5e396", "TestID" -> 
          "Utilities-SupportedFileQ-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Utilities.wlt", "EvaluationID" -> 
-         "9182bd63-cd7d-4c86-8f70-3a8b95df4eac", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Utilities.wlt", "EvaluationID" -> 
+         "5a59efbd-2f09-4ac5-8bd4-70c7d8a9101e", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`Utilities`SupportedFileQ[
             File[
              
@@ -4610,90 +4613,90 @@ Tests/Utilities.wlt", "EvaluationID" ->
                "TextSearch", "TextSearch.m"}]]]], "ExpectedOutput" -> 
          HoldForm[False], "ExpectedMessages" -> HoldForm[{}], "ActualOutput" -> 
          HoldForm[False], "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000147`2.3178323325801675, "CPUTimeUsed" -> 
-         0.00014799999999937086`, "MemoryUsed" -> 4176, 
+         0.000154`2.3380357186684573, "CPUTimeUsed" -> 
+         0.00015499999999946112`, "MemoryUsed" -> 4208, 
          "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 1240995355499861527 -> 
+         None|>], 2124912635609429805 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055285784`15.64868523725676*^9, "SameTest" -> SameQ, 
+         3.941652568482041`15.649283326167469*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "e4a1e156-37a0-4a55-a537-ba825777ceea", "TestID" -> 
+         "CreationID" -> "69002f17-cf22-4a45-96c7-0a54ac456657", "TestID" -> 
          "Utilities-UnwrapAlternatives-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Utilities.wlt", "EvaluationID" -> 
-         "e187d305-009a-4731-9471-901aaa75212f", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Utilities.wlt", "EvaluationID" -> 
+         "6d6d467e-5c58-4617-94c0-383e69130917", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`Utilities`UnwrapAlternatives[{
              Alternatives["A", "B"]}]], "ExpectedOutput" -> HoldForm[
            Alternatives["A", "B"]], "ExpectedMessages" -> HoldForm[{}], 
          "ActualOutput" -> HoldForm[
            Alternatives["A", "B"]], "ActualMessages" -> {}, 
-         "AbsoluteTimeUsed" -> 0.00002`1.4515449934959728, "CPUTimeUsed" -> 
-         0.000018999999999991246`, "MemoryUsed" -> 3400, 
+         "AbsoluteTimeUsed" -> 0.00002`1.451544993495975, "CPUTimeUsed" -> 
+         0.000020000000001019203`, "MemoryUsed" -> 3400, 
          "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 4885687200266534195 -> 
+         None|>], 7116722518602375262 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055285935`15.648685237256776*^9, "SameTest" -> SameQ, 
+         3.941652568482201`15.649283326167486*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "292aa472-b8ce-4a13-adc0-93fd0d3deb32", "TestID" -> 
+         "CreationID" -> "ca4d7c72-f047-4854-b77b-b9ea27b0bcfc", "TestID" -> 
          "Utilities-WrapAlternatives-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Utilities.wlt", "EvaluationID" -> 
-         "45807d09-3226-467d-94f0-c09e81e7f162", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Utilities.wlt", "EvaluationID" -> 
+         "a2697202-cd6a-47fe-b355-8a9a09e0bc4c", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`Utilities`WrapAlternatives[
             Alternatives["A", "B"]]], "ExpectedOutput" -> HoldForm[{
             Alternatives["A", "B"]}], "ExpectedMessages" -> HoldForm[{}], 
          "ActualOutput" -> HoldForm[{
             Alternatives["A", "B"]}], "ActualMessages" -> {}, 
-         "AbsoluteTimeUsed" -> 0.00002`1.4515449934959728, "CPUTimeUsed" -> 
+         "AbsoluteTimeUsed" -> 0.00002`1.451544993495975, "CPUTimeUsed" -> 
          0.000019999999999242846`, "MemoryUsed" -> 3448, 
          "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 583241384740232249 -> 
+         None|>], 4058911016571700575 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055286083`15.648685237256794*^9, "SameTest" -> SameQ, 
-         "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
+         3.9416525684823570000000000001`15.649283326167502*^9, "SameTest" -> 
+         SameQ, "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "07e43665-0564-42e8-a50f-0505c8566b54", "TestID" -> 
+         "CreationID" -> "5c3127b0-ca31-48bf-9ab8-51aa19f74b3c", "TestID" -> 
          "Utilities-StopWordQ-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Utilities.wlt", "EvaluationID" -> 
-         "678eb0d3-3d93-499e-ae44-63c57d9f6b0f", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Utilities.wlt", "EvaluationID" -> 
+         "220b4d6c-381a-444d-a78b-839a65298fd8", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`StopWordQ["the"]], "ExpectedOutput" -> 
          HoldForm[True], "ExpectedMessages" -> HoldForm[{}], "ActualOutput" -> 
          HoldForm[True], "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.007145`4.004517230958979, "CPUTimeUsed" -> 0.007171000000001371, 
-         "MemoryUsed" -> 6096, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 2773115885234793492 -> 
+         0.007488`4.024880833562043, "CPUTimeUsed" -> 0.007493000000000194, 
+         "MemoryUsed" -> 5968, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 5499043419684617855 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055286202`15.648685237256807*^9, "SameTest" -> SameQ, 
+         3.941652568482485`15.649283326167517*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "5ab9d49d-86ff-47a4-bd70-cbf1f97857bc", "TestID" -> 
+         "CreationID" -> "dfec4a78-dac3-4bbd-a3b6-4ce33ab00005", "TestID" -> 
          "Utilities-StopWordQ-Test2", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Utilities.wlt", "EvaluationID" -> 
-         "5c738ebe-9121-438e-b5c1-e03362eac327", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Utilities.wlt", "EvaluationID" -> 
+         "0da10d1d-c3ba-484d-a8a2-0d62bb091ce0", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`StopWordQ["math"]], "ExpectedOutput" -> 
          HoldForm[False], "ExpectedMessages" -> HoldForm[{}], "ActualOutput" -> 
          HoldForm[False], "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.000034`1.6819939148742462, "CPUTimeUsed" -> 0.00003399999999942338,
+         0.000035`1.6945830421822692, "CPUTimeUsed" -> 0.00003500000000045134,
           "MemoryUsed" -> 3400, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 1238666566390366556 -> 
+         "Success", "FailureType" -> None|>], 8331758758574563836 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055286386`15.648685237256824*^9, "SameTest" -> SameQ, 
-         "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
+         3.9416525684826690000000000001`15.649283326167538*^9, "SameTest" -> 
+         SameQ, "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "d1054e7d-168b-4444-a0d4-6a00d78986ba", "TestID" -> 
+         "CreationID" -> "e19ea402-5007-42e2-a132-f8e6e14dc6cf", "TestID" -> 
          "Utilities-ExpandPattern-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Utilities.wlt", "EvaluationID" -> 
-         "7381fa72-847d-4f26-83da-9f6a170f5c17", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Utilities.wlt", "EvaluationID" -> 
+         "ac2c3e83-d09f-4626-b530-cc8094996f00", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`ExpandPattern[
            FaizonZaman`LexicalCases`$SampleParagraph, 
             FaizonZaman`LexicalCases`BoundToken[
@@ -4727,20 +4730,20 @@ Tests/Utilities.wlt", "EvaluationID" ->
              "words", "fingers", "weeks", "writer", "block", "screen", 
               "front", "day", "mind", "type", "word", "process", "hours", 
               "computer", "today", "blank"]]]], "ActualMessages" -> {}, 
-         "AbsoluteTimeUsed" -> 0.029592`4.621689316139327, "CPUTimeUsed" -> 
-         0.11424900000000093`, "MemoryUsed" -> 5088, 
+         "AbsoluteTimeUsed" -> 0.014154`4.301394189101233, "CPUTimeUsed" -> 
+         0.01919299999999957, "MemoryUsed" -> 5152, 
          "IntermediateTestsTree" -> {}, "Outcome" -> "Success", "FailureType" -> 
-         None|>], 6954307660999919203 -> 
+         None|>], 2949627495802036964 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055286514`15.648685237256842*^9, "SameTest" -> SameQ, 
+         3.941652568482799`15.64928332616755*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "c62d7a1a-a3aa-437a-84b8-b4d38f0e4a29", "TestID" -> 
+         "CreationID" -> "eefdd33e-c83a-44d0-b561-85fb997aa408", "TestID" -> 
          "Utilities-ExpandPattern-Test2", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Utilities.wlt", "EvaluationID" -> 
-         "4b9b6249-393d-4f79-9cbd-bab4c06b1c18", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Utilities.wlt", "EvaluationID" -> 
+         "2f2b5612-64e2-457a-aab0-8aec7d3c7e9c", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`ExpandPattern[
            "this is the best music ever.", 
             StringExpression[
@@ -4748,19 +4751,19 @@ Tests/Utilities.wlt", "EvaluationID" ->
          "ExpectedOutput" -> HoldForm["best music"], "ExpectedMessages" -> 
          HoldForm[{}], "ActualOutput" -> HoldForm["best music"], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.004205`3.774280997965923, "CPUTimeUsed" -> 0.003399000000001706, 
-         "MemoryUsed" -> 3712, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 8537523514079557897 -> 
+         0.004229`3.7767526829788944, "CPUTimeUsed" -> 0.0034600000000004627`,
+          "MemoryUsed" -> 3712, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 1674766146717871421 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055286647`15.648685237256855*^9, "SameTest" -> SameQ, 
-         "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
+         3.9416525684829320000000000001`15.649283326167566*^9, "SameTest" -> 
+         SameQ, "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "a94061b6-c7cc-4662-bc92-b0b19a5c9cd9", "TestID" -> 
+         "CreationID" -> "4c3d5f5c-3a4e-4668-b777-ca731e5682a8", "TestID" -> 
          "Utilities-ExpandPattern-Test3", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Utilities.wlt", "EvaluationID" -> 
-         "064c758e-4f77-46a3-acf5-74208bae2afe", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Utilities.wlt", "EvaluationID" -> 
+         "fcbbaea4-da75-4903-bad4-fa23f3ea0879", "Input" -> HoldForm[
            FaizonZaman`LexicalCases`ExpandPattern["to be.", 
             StringExpression[
              FaizonZaman`LexicalCases`WordToken[1], 
@@ -4772,19 +4775,19 @@ Tests/Utilities.wlt", "EvaluationID" ->
            StringExpression[WordBoundary, 
             Repeated[WordCharacter], WordBoundary, "be"]], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.005242`3.870012014442571, "CPUTimeUsed" -> 0.004799999999999471, 
-         "MemoryUsed" -> -5520, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 543815464254506919 -> 
+         0.004756`3.8277568437786478, "CPUTimeUsed" -> 0.004229999999999734, 
+         "MemoryUsed" -> -5320, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 8038238170699046069 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055286799`15.64868523725687*^9, "SameTest" -> SameQ, 
+         3.941652568483092`15.649283326167584*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "8eafc9ca-f359-45f9-9809-ed7d8ad934aa", "TestID" -> 
+         "CreationID" -> "7d186b11-fdf3-407f-a1a3-c740d2620de1", "TestID" -> 
          "Utilities-LexicalPattern-Test1", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Utilities.wlt", "EvaluationID" -> 
-         "a47a5d11-2913-40eb-ae0e-13c61b18ff09", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Utilities.wlt", "EvaluationID" -> 
+         "e0b5da08-1bfe-4a10-891a-c610c9895c6b", "Input" -> HoldForm[
            StringCases[FaizonZaman`LexicalCases`$SampleParagraph, 
             FaizonZaman`LexicalCases`LexicalPattern[
              StringExpression[
@@ -4795,19 +4798,19 @@ Tests/Utilities.wlt", "EvaluationID" ->
          "ExpectedMessages" -> HoldForm[{}], "ActualOutput" -> 
          HoldForm[{"blank screen", "blank screen", "the screen"}], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.025692`4.560312911174055, "CPUTimeUsed" -> 0.07447999999999944, 
-         "MemoryUsed" -> 12544, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 1537392702881551798 -> 
+         0.014986`4.326200726094076, "CPUTimeUsed" -> 0.033714000000001576`, 
+         "MemoryUsed" -> 4664, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 1730614785699171155 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055286922`15.648685237256885*^9, "SameTest" -> SameQ, 
+         3.941652568483221`15.649283326167597*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "e7b7dfdc-b8b4-4794-bd9b-355dc53a5d5f", "TestID" -> 
+         "CreationID" -> "39dfe5ea-e562-47ce-8727-21ef36902fdb", "TestID" -> 
          "Utilities-LexicalPattern-Test2", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Utilities.wlt", "EvaluationID" -> 
-         "a57f7ca2-028a-4082-82c1-67f4069d1998", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Utilities.wlt", "EvaluationID" -> 
+         "a09f616e-baf1-4f54-a16a-634b7deaecc4", "Input" -> HoldForm[
            StringCases[FaizonZaman`LexicalCases`$SampleParagraph, 
             FaizonZaman`LexicalCases`LexicalPattern[
              StringExpression[
@@ -4818,19 +4821,19 @@ Tests/Utilities.wlt", "EvaluationID" ->
          "ExpectedMessages" -> HoldForm[{}], "ActualOutput" -> 
          HoldForm[{"blank screen", "blank screen", "the screen"}], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.024847`4.54578895781897, "CPUTimeUsed" -> 0.0964690000000008, 
-         "MemoryUsed" -> 4752, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 6432204049439303241 -> 
+         0.014572`4.314034160401873, "CPUTimeUsed" -> 0.021635000000001625`, 
+         "MemoryUsed" -> 12512, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 8851649309124455093 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.93622805528706`15.6486852372569*^9, "SameTest" -> SameQ, 
+         3.941652568483353`15.64928332616761*^9, "SameTest" -> SameQ, 
          "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "8bc58699-d8fe-47a6-b3f7-16e2f92d4344", "TestID" -> 
+         "CreationID" -> "2c6ffa2f-e27d-4f17-bcea-4fe7acfb5a26", "TestID" -> 
          "Utilities-LexicalPattern-Test3", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Utilities.wlt", "EvaluationID" -> 
-         "e09c27c6-6e81-42a0-a67a-71e760e65d4b", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Utilities.wlt", "EvaluationID" -> 
+         "c51042e8-4f52-4301-adf7-42199010f295", "Input" -> HoldForm[
            StringPosition[FaizonZaman`LexicalCases`$SampleParagraph, 
             FaizonZaman`LexicalCases`LexicalPattern[
              StringExpression[
@@ -4841,19 +4844,19 @@ Tests/Utilities.wlt", "EvaluationID" ->
          HoldForm[{{144, 160}, {176, 201}}], "ExpectedMessages" -> 
          HoldForm[{}], "ActualOutput" -> HoldForm[{{144, 160}, {176, 201}}], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.030614`4.636435075695696, "CPUTimeUsed" -> 0.1133620000000004, 
-         "MemoryUsed" -> 7520, "IntermediateTestsTree" -> {}, "Outcome" -> 
-         "Success", "FailureType" -> None|>], 8728356131339260596 -> 
+         0.014867`4.322738339259747, "CPUTimeUsed" -> 0.0178130000000003, 
+         "MemoryUsed" -> 7584, "IntermediateTestsTree" -> {}, "Outcome" -> 
+         "Success", "FailureType" -> None|>], 3403690592333606343 -> 
       TestObject[<|
         "MetaInformation" -> None, "AbsoluteTime" -> 
-         3.936228055287186`15.648685237256913*^9, "SameTest" -> SameQ, 
-         "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
+         3.9416525684834810000000000001`15.649283326167627*^9, "SameTest" -> 
+         SameQ, "SameMessages" -> Testing`MessageMatchQ, "MemoryConstraint" -> 
          DirectedInfinity[1], "TimeConstraint" -> DirectedInfinity[1], 
-         "CreationID" -> "4f131999-3fa0-4b25-a981-5464d15272bc", "TestID" -> 
+         "CreationID" -> "a6d01a89-30c2-479c-94bc-ff1e3220bd90", "TestID" -> 
          "Utilities-LexicalPattern-Test4", "TestFileName" -> 
-         "/Users/faizonzaman/Developer/LexicalCases/FaizonZaman/LexicalCases/\
-Tests/Utilities.wlt", "EvaluationID" -> 
-         "0d00d049-179d-4716-b51c-6a527e8d46ca", "Input" -> HoldForm[
+         "/Users/faizonzaman/Developer/wolfram/LexicalCases/FaizonZaman/\
+LexicalCases/Tests/Utilities.wlt", "EvaluationID" -> 
+         "4dc9d057-0dd3-4ed6-87ab-8d4c9f626e27", "Input" -> HoldForm[
            StringMatchQ["Alice walked quickly", 
             FaizonZaman`LexicalCases`LexicalPattern[
              StringExpression["Alice ", 
@@ -4862,42 +4865,44 @@ Tests/Utilities.wlt", "EvaluationID" ->
          "ExpectedOutput" -> HoldForm[True], "ExpectedMessages" -> 
          HoldForm[{}], "ActualOutput" -> HoldForm[True], 
          "ActualMessages" -> {}, "AbsoluteTimeUsed" -> 
-         0.004624`3.8155328232444643, "CPUTimeUsed" -> 0.004026000000001417, 
+         0.004807`3.832389119960641, "CPUTimeUsed" -> 0.004212000000000771, 
          "MemoryUsed" -> 3976, "IntermediateTestsTree" -> {}, "Outcome" -> 
          "Success", "FailureType" -> None|>]|>, "FailureResults" -> <||>, 
     "TestsNotEvaluatedKeys" -> {}, "TestsFailedWrongResultsKeys" -> {}, 
     "TestsFailedWithMessagesKeys" -> {}, 
     "TestsSucceededKeys" -> CompressedData["
-1:eJw9lc1tZEcMhHXYBOyNwBmw+c8QBBg+OAQfDOxpD+v84a9f95MEvRlxusli
-VZHzxz8///73r4+Pj1/fePz549d/n995s1Ys8bRoXzoS3vX5O3ENqcml7qss
-i8dzvMW6MotPasRmcfxJo9NT7RqcbXEZPec1K2K0JNtGetU88WwyS4aqrG6y
-2YmruchY6lqZbp3eJ15ZHI0ycRuuzjm/PEqo7BKRsoYLT7w6tJdXANNNytbB
-v6rLyjkM8vLWziduSrR02RrNMLMb13RVN/dxOjR78SwK2a5a6bA3sHV50Bxd
-swtbzaK7J04KkpOKImmVcvN4caNEgUNyks7Jo01bHFUheel4XJybTTgg/Srl
-zTo8dFaleQ2/7i3zhXMG3qAo4aAcSU9ddFfa3/iX08uqyxu9W8AASlGk17q6
-jygBTMEdkZDDJ70GOIMbnooQkpcHl1W0DwtIt+z6hFZkpfLSwaNe/xihKLqB
-/odWO/kTi6Af10OpvOsffmiS+Np2wCmSrz+t1jYs8FuaWykHp3hth/Nhia0l
-dfyJYeme0raUKiv79BtkBHrsZr3gOg5OBGIasC2UheH5PP0iqPWgHipnZCLy
-PS+9xYUOlMagr761XemDiOVUfvmkew361UYbWmYaXpzL9/Q0NNMFzr66EO7t
-b57qm76TB0Ma/3bOzArh9eKk4eptcZVH5ve8AxO5RpKftpbP3zZvMI/XWwRT
-D+QeFbEwSVgEmw32QF236SahG+TK+8g7pRbV2Nw7yAH7uPLkCa7TDxAdtk0v
-Ow8SimwaKpbGVYW+ud+rV1AoMLFf1jY9rDDdQ5yxOp4l5gtnIEgG5NCIn3CO
-E+/ZpFlOXg9mALPxMUNpzJC/cdoApqujfO9urwdBiXsQl03jub1yvYnJZbth
-+ItnRndZdk7iBia7QAB6fctyMg1yGkPwz5GcdbEHEGdDu0nLtRpCSfRehmwl
-tkNfCZnBJos2cdbaesVyfYqhEyED7ryjhQO3TWTbnJmbA3MLjSIYq5IxaI+r
-ycLDW6SiJrKEfk36TNjTBWXBfMpiA5hVnAP/BgmH/GhTZx84Y657I14yGTd2
-Epd0rzG8q1+WwpCMFF8fW8m7CBP5Qc7oz3Y4S+4ugNhTa7HBzhZ0zvcZp3ud
-WXe6mrs3MRLt7A3cfBx7wO7cAo2vMfa+zZ5Hv3uwtPE13xPGNYSY/B8W+k6w
-
+1:eJw1lU1u1TEMxLvgAsAJuEH8bR+hEmLBEVggsWJR7i9++SdPqqrXvMQez4yn
+3379/fn7x9vb28cnfn3/8/Hv/SsfylKXl4/K6taq6ufcPWt5RMuUu0anP+eZ
+Y+VRbsWDtNG8524ry2ZqRXe0ruc8lEu1f3mtqUqx9y+cG91ELc3EtdrnlG+1
+8daedtGYXKue6yKgbBp3+BoA9fvnXWWEK2vFrKFQ6FNEpTWSx4DTZR2lTxGX
+CnBIpSYvVM71WSEumT2uGiupc6AP7cYysobZUlLu/aKurIAg02xbc7CL9aIQ
+CNfM6gL7Q3FZiFhQjalCNc99nTB+1IKzXjV9+jrdWmCwLawpL+f8KT7ZscR9
+6ECdh0pVBz2ihIaZx2GesZlsOExulvqFQzMFDcrxlRfK1m0LlnABEJ+gpA89
+7ahRMnAh5SsjDg1QCNGiu0kuM1t2adMOATvUM4LKXIc07Dqi5LhtluKMBWAd
+BAiKBMZa6henwzNATDp5Wn7qIFPmEmgRgTTn8b3PvD77mxFJp8mZSxC08rkO
+dWpy5VqFT0GrS9MTbV48APJxA3qhcM6lfxBl263Mto5x7xdsCU6TQjNmKT+8
+mVSjCrZlFzB7XV0cu9V+tB0NCXl5K7RDGLDSB1x9+0pgYQayBdIQfHvvp7Oa
+uc28pcTOhzervbjGlvZWHgecjesqGHAU4STBdt0vWDy3WYE5hqn7bhze80jf
+NmUwPde53UwWxibv7Gi/aLAeZkgGGtm3/bpkOoWNQICk/16Xc64sVHDc7Irs
+UdbTNrjsq8kQeGHh5YoC6sTmzfhYZHv4xhQyMEzrDoidF6ctThL2qRfPBC6Y
+8IjYmSiKVGdmduZpi79Y99lYcDmmOyTozj56JK5BmbiWYsS1PUUuElL4Z+5G
+J0PZYE+8z6rKTTU0YIOe/UFvrHnRsyIqj+wbEnO43wADmRRmRUGE1DsV4Wd7
+FQRfQbC8wteweG2X+7Y+M9o9J1mDkUQhCFb1WhZ0lMA5yE215dcLsIsrSWO0
+3Bbq16pgRkjk/wSWGoLZ4uJU50+WlLXGKMh2zIBda+NERLWdQPqyPiTIYvsZ
+l9ium7TEGZvmREU7vuobDW3bas0PoxHdfedSpEq0mS3ww/Thja64gQDHaptx
+18sbVlKmKYKQRjsPz/2yHff045z9lVdfAix3DDMc6gd7caNqNyPvlLijirn9
+By2wTYs=
      "]|>],
   Editable->False,
   SelectWithContents->True,
   Selectable->False]], "Output", "Excluded",
  CellChangeTimes->{
   3.933090205649231*^9, 3.9330904420148706`*^9, {3.933090690381926*^9, 
-   3.9330907175028677`*^9}, 3.936228060670979*^9},
+   3.9330907175028677`*^9}, 3.936228060670979*^9, 3.941645496788391*^9, 
+   3.9416516809549828`*^9, 3.941651838186666*^9, 3.941652269660158*^9, 
+   3.941652574808415*^9},
  CellLabel->"Out[1]=",
- CellID->1091197983,ExpressionUUID->"28813ec0-6e47-4581-94e8-7b2af0944cfa"]
+ CellID->1016709158,ExpressionUUID->"8be3a836-8d32-4956-9623-627a40a4eb12"]
 }, Open  ]]
 }, Open  ]],
 
@@ -10665,8 +10670,8 @@ Cell[BoxData[
            CheckboxBox[False, {False, "Social, Cultural & Linguistic Data"}], 
            "\" \"", 
            StyleBox[
-           "\"Social, Cultural & Linguistic Data\"", FontSize -> 12, Editable -> 
-            False, StripOnInput -> False]},
+           "\"Social, Cultural & Linguistic Data\"", FontSize -> 12, 
+            Editable -> False, StripOnInput -> False]},
           "RowDefault"]},
         {
          TemplateBox[{
@@ -12341,8 +12346,8 @@ Cell[BoxData[
 }, Open  ]]
 }, Open  ]]
 },
-WindowSize->{1295, 847},
-WindowMargins->{{Automatic, 1039}, {Automatic, -401}},
+WindowSize->{678, 846},
+WindowMargins->{{0, Automatic}, {Automatic, 0}},
 DockedCells->{
   Cell[
    BoxData[


### PR DESCRIPTION
Fixes #338

* Adds wrapping calls of Mass(Word|Synonym)Token